### PR TITLE
feat: add model exporter profiles for ChatML, Alpaca, and ShareGPT

### DIFF
--- a/.github/workflows/model-exporters.yml
+++ b/.github/workflows/model-exporters.yml
@@ -1,0 +1,31 @@
+name: PeachTree Model Exporters CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/peachtree/exporters.py"
+      - "src/peachtree/cli.py"
+      - "tests/test_exporters.py"
+      - "docs/MODEL_EXPORTERS.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  model-exporters:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - run: pytest -q tests/test_exporters.py
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -110,3 +110,16 @@ peachtree ecosystem --inventory data/manifests/owned.jsonl --output reports/ecos
 ```
 
 These commands read local inventory, datasets, and manifests. They do not contact GitHub or train models.
+
+
+## Model exporter profiles
+
+PeachTree v0.4.0 exports reviewed PeachTree datasets into ChatML, Alpaca, and ShareGPT JSONL.
+
+```bash
+peachtree export-formats
+peachtree export --source data/datasets/peachfuzz-instruct.jsonl --format chatml --output data/exports/peachfuzz-chatml.jsonl
+peachtree validate-export --format chatml --path data/exports/peachfuzz-chatml.jsonl
+```
+
+Exporters are local-only and preserve provenance metadata by default.

--- a/docs/MODEL_EXPORTERS.md
+++ b/docs/MODEL_EXPORTERS.md
@@ -1,0 +1,51 @@
+# Model Exporter Profiles
+
+PeachTree v0.4.0 adds local-only model dataset exporters for common fine-tuning schemas:
+
+- ChatML
+- Alpaca
+- ShareGPT
+
+The exporters convert reviewed PeachTree dataset JSONL into model-specific training JSONL. They do **not** train models, upload data, contact APIs, or mutate source datasets.
+
+## Commands
+
+```bash
+peachtree export-formats
+
+peachtree export \
+  --source data/datasets/0ai-Cyberviser__peachfuzz-instruct.jsonl \
+  --format chatml \
+  --output data/exports/peachfuzz-chatml.jsonl
+
+peachtree export \
+  --source data/datasets/0ai-Cyberviser__peachfuzz-instruct.jsonl \
+  --format alpaca \
+  --output data/exports/peachfuzz-alpaca.jsonl
+
+peachtree export \
+  --source data/datasets/0ai-Cyberviser__peachfuzz-instruct.jsonl \
+  --format sharegpt \
+  --output data/exports/peachfuzz-sharegpt.jsonl
+```
+
+## Validate exports
+
+```bash
+peachtree validate-export --format chatml --path data/exports/peachfuzz-chatml.jsonl
+peachtree validate-export --format alpaca --path data/exports/peachfuzz-alpaca.jsonl
+peachtree validate-export --format sharegpt --path data/exports/peachfuzz-sharegpt.jsonl
+```
+
+## Safety model
+
+Exporters are local-only:
+
+- no network calls
+- no training execution
+- no background jobs
+- no shell execution
+- preserves source provenance metadata by default
+- supports `--no-metadata` only when a downstream trainer requires plain schema
+
+Review exported datasets before model training.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@
 - Hancock/PeachFuzz/PeachTree lineage maps
 
 ## v0.4.0
-- Exporters: ChatML, Alpaca, ShareGPT
+- Exporters: ChatML, Alpaca, ShareGPT ✅
 
 ## v0.5.0
 - GitHub Actions scheduled dataset update PR workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peachtree-ai"
-version = "0.3.0"
+version = "0.4.0"
 description = "Recursive learning-tree dataset engine for safe AI model training pipelines"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/peachtree/__init__.py
+++ b/src/peachtree/__init__.py
@@ -4,6 +4,7 @@ from .planner import RecursiveLearningTree
 from .github_owned import OwnedGitHubConnector, OwnedRepo
 from .dependency_graph import DependencyGraphBuilder, DependencyGraph
 from .lineage import DatasetLineageBuilder, DatasetLineage
+from .exporters import ModelExporter, export_format_names
 from .safety import SafetyGate
 
 __all__ = [
@@ -20,6 +21,8 @@ __all__ = [
     "DependencyGraph",
     "DatasetLineageBuilder",
     "DatasetLineage",
+    "ModelExporter",
+    "export_format_names",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/peachtree/builder.py
+++ b/src/peachtree/builder.py
@@ -55,7 +55,7 @@ class DatasetBuilder:
             record_count=len(records),
             source_count=len(sources),
             domain=self.domain,
-            builder_version="0.3.0",
+            builder_version="0.4.0",
             source_digests=tuple(sorted({source.digest for source in sources})),
             policy={"secret_filtering": True, "license_filtering": True, "provenance_required": True},
         )

--- a/src/peachtree/cli.py
+++ b/src/peachtree/cli.py
@@ -12,6 +12,7 @@ from .safety import SafetyGate
 from .github_owned import OwnedGitHubConnector
 from .dependency_graph import DependencyGraphBuilder
 from .lineage import DatasetLineageBuilder
+from .exporters import ModelExporter, export_format_names
 
 
 def run_plan(args: argparse.Namespace) -> int:
@@ -150,6 +151,25 @@ def run_ecosystem(args: argparse.Namespace) -> int:
     _print_or_write(content, args.output)
     return 0
 
+
+
+def run_export_formats(args: argparse.Namespace) -> int:
+    print(json.dumps({"formats": list(export_format_names())}, indent=2, sort_keys=True))
+    return 0
+
+
+def run_export(args: argparse.Namespace) -> int:
+    exporter = ModelExporter(system_prompt=args.system_prompt, include_metadata=not args.no_metadata)
+    stats = exporter.export_file(args.source, args.output, args.format, limit=args.limit)
+    print(stats.to_json())
+    return 0 if stats.records_written > 0 else 1
+
+
+def run_validate_export(args: argparse.Namespace) -> int:
+    report = ModelExporter().validate_export(args.path, args.format)
+    print(report.to_json())
+    return 0 if report.ok else 1
+
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="peachtree", description="Recursive learning-tree dataset engine")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -218,6 +238,23 @@ def make_parser() -> argparse.ArgumentParser:
     ecosystem.add_argument("--manifest-dir", default="data/manifests")
     ecosystem.add_argument("--output")
     ecosystem.set_defaults(func=run_ecosystem)
+
+    export_formats = sub.add_parser("export-formats", help="list supported model export formats")
+    export_formats.set_defaults(func=run_export_formats)
+
+    export = sub.add_parser("export", help="export PeachTree dataset JSONL to a model training schema")
+    export.add_argument("--source", required=True, help="PeachTree dataset JSONL")
+    export.add_argument("--output", required=True, help="output JSONL path")
+    export.add_argument("--format", choices=list(export_format_names()), required=True)
+    export.add_argument("--system-prompt", default="You are a helpful, safe, and precise AI assistant.")
+    export.add_argument("--limit", type=int)
+    export.add_argument("--no-metadata", action="store_true")
+    export.set_defaults(func=run_export)
+
+    validate_export = sub.add_parser("validate-export", help="validate exported model JSONL")
+    validate_export.add_argument("--path", required=True)
+    validate_export.add_argument("--format", choices=list(export_format_names()), required=True)
+    validate_export.set_defaults(func=run_validate_export)
 
     policy = sub.add_parser("policy", help="show collection safety policy")
     policy.set_defaults(func=run_policy)

--- a/src/peachtree/exporters.py
+++ b/src/peachtree/exporters.py
@@ -1,0 +1,262 @@
+"""Model exporter profiles for PeachTree datasets.
+
+The exporter reads PeachTree JSONL datasets and converts them into common
+fine-tuning schemas. It is local-only and does not train models.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SUPPORTED_EXPORT_FORMATS = ("chatml", "alpaca", "sharegpt")
+
+
+@dataclass(frozen=True)
+class ExportIssue:
+    line: int
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExportStats:
+    source_path: str
+    output_path: str
+    format: str
+    records_read: int
+    records_written: int
+    issues: tuple[ExportIssue, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues and self.records_written > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_path": self.source_path,
+            "output_path": self.output_path,
+            "format": self.format,
+            "records_read": self.records_read,
+            "records_written": self.records_written,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "ok": self.ok,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    path: str
+    format: str
+    records: int
+    issues: tuple[ExportIssue, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues and self.records > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "format": self.format,
+            "records": self.records,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "ok": self.ok,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+def export_format_names() -> tuple[str, ...]:
+    return SUPPORTED_EXPORT_FORMATS
+
+
+def normalize_format(name: str) -> str:
+    normalized = name.strip().lower()
+    if normalized not in SUPPORTED_EXPORT_FORMATS:
+        raise ValueError(f"unsupported export format: {name}")
+    return normalized
+
+
+class ModelExporter:
+    """Converts PeachTree instruction JSONL into training export schemas."""
+
+    def __init__(
+        self,
+        system_prompt: str = "You are a helpful, safe, and precise AI assistant.",
+        include_metadata: bool = True,
+    ) -> None:
+        self.system_prompt = system_prompt
+        self.include_metadata = include_metadata
+
+    def export_file(
+        self,
+        source_path: str | Path,
+        output_path: str | Path,
+        export_format: str,
+        limit: int | None = None,
+    ) -> ExportStats:
+        fmt = normalize_format(export_format)
+        source = Path(source_path)
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        issues: list[ExportIssue] = []
+        written = 0
+        read = 0
+        lines: list[str] = []
+
+        for line_number, record in self._iter_jsonl(source):
+            read += 1
+            try:
+                exported = self.convert_record(record, fmt)
+            except ValueError as exc:
+                issues.append(ExportIssue(line_number, str(exc)))
+                continue
+            lines.append(json.dumps(exported, sort_keys=True, ensure_ascii=False))
+            written += 1
+            if limit is not None and written >= limit:
+                break
+
+        output.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+        return ExportStats(str(source), str(output), fmt, read, written, tuple(issues))
+
+    def convert_record(self, record: dict[str, Any], export_format: str) -> dict[str, Any]:
+        fmt = normalize_format(export_format)
+        instruction = str(record.get("instruction", "")).strip()
+        user_input = str(record.get("input", "")).strip()
+        output = str(record.get("output", "")).strip()
+
+        if not instruction:
+            raise ValueError("missing instruction")
+        if not output:
+            raise ValueError("missing output")
+
+        if fmt == "chatml":
+            return self._to_chatml(record, instruction, user_input, output)
+        if fmt == "alpaca":
+            return self._to_alpaca(record, instruction, user_input, output)
+        if fmt == "sharegpt":
+            return self._to_sharegpt(record, instruction, user_input, output)
+        raise ValueError(f"unsupported export format: {export_format}")
+
+    def validate_export(self, path: str | Path, export_format: str) -> ValidationReport:
+        fmt = normalize_format(export_format)
+        issues: list[ExportIssue] = []
+        records = 0
+        for line_number, record in self._iter_jsonl(Path(path)):
+            records += 1
+            issue = self._validate_record(record, fmt)
+            if issue:
+                issues.append(ExportIssue(line_number, issue))
+        return ValidationReport(str(path), fmt, records, tuple(issues))
+
+    def _to_chatml(self, record: dict[str, Any], instruction: str, user_input: str, output: str) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "messages": [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": self._join_instruction_input(instruction, user_input)},
+                {"role": "assistant", "content": output},
+            ]
+        }
+        if self.include_metadata:
+            item["metadata"] = self._metadata(record)
+        return item
+
+    def _to_alpaca(self, record: dict[str, Any], instruction: str, user_input: str, output: str) -> dict[str, Any]:
+        item: dict[str, Any] = {"instruction": instruction, "input": user_input, "output": output}
+        if self.include_metadata:
+            item["metadata"] = self._metadata(record)
+        return item
+
+    def _to_sharegpt(self, record: dict[str, Any], instruction: str, user_input: str, output: str) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "conversations": [
+                {"from": "system", "value": self.system_prompt},
+                {"from": "human", "value": self._join_instruction_input(instruction, user_input)},
+                {"from": "gpt", "value": output},
+            ]
+        }
+        record_id = str(record.get("id", "")).strip()
+        if record_id:
+            item["id"] = record_id
+        if self.include_metadata:
+            item["metadata"] = self._metadata(record)
+        return item
+
+    @staticmethod
+    def _join_instruction_input(instruction: str, user_input: str) -> str:
+        return f"{instruction}\n\n{user_input}" if user_input else instruction
+
+    @staticmethod
+    def _metadata(record: dict[str, Any]) -> dict[str, Any]:
+        keys = (
+            "id",
+            "domain",
+            "source_repo",
+            "source_path",
+            "source_digest",
+            "license_id",
+            "quality_score",
+            "safety_score",
+            "record_type",
+            "created_at",
+        )
+        return {key: record[key] for key in keys if key in record}
+
+    @staticmethod
+    def _iter_jsonl(path: Path) -> Iterable[tuple[int, dict[str, Any]]]:
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                yield line_number, {"instruction": "", "output": "", "_invalid_json": True}
+                continue
+            if isinstance(value, dict):
+                yield line_number, value
+            else:
+                yield line_number, {"instruction": "", "output": "", "_invalid_type": type(value).__name__}
+
+    def _validate_record(self, record: dict[str, Any], export_format: str) -> str | None:
+        fmt = normalize_format(export_format)
+        if fmt == "chatml":
+            messages = record.get("messages")
+            if not isinstance(messages, list) or len(messages) < 2:
+                return "chatml record must contain messages list"
+            roles = [message.get("role") for message in messages if isinstance(message, dict)]
+            if "user" not in roles or "assistant" not in roles:
+                return "chatml messages must include user and assistant roles"
+            for message in messages:
+                if not isinstance(message, dict) or not message.get("content"):
+                    return "chatml message missing content"
+            return None
+        if fmt == "alpaca":
+            if not record.get("instruction"):
+                return "alpaca record missing instruction"
+            if "input" not in record:
+                return "alpaca record missing input field"
+            if not record.get("output"):
+                return "alpaca record missing output"
+            return None
+        if fmt == "sharegpt":
+            conversations = record.get("conversations")
+            if not isinstance(conversations, list) or len(conversations) < 2:
+                return "sharegpt record must contain conversations list"
+            speakers = [message.get("from") for message in conversations if isinstance(message, dict)]
+            if "human" not in speakers or "gpt" not in speakers:
+                return "sharegpt conversations must include human and gpt turns"
+            for message in conversations:
+                if not isinstance(message, dict) or not message.get("value"):
+                    return "sharegpt message missing value"
+            return None
+        return f"unsupported export format: {export_format}"

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,180 @@
+from pathlib import Path
+import json
+
+from peachtree.cli import main
+from peachtree.exporters import ModelExporter, export_format_names
+
+
+def _dataset(tmp_path: Path) -> Path:
+    path = tmp_path / "dataset.jsonl"
+    records = [
+        {
+            "id": "rec-1",
+            "instruction": "Explain this source.",
+            "input": "Repository: demo\nPath: README.md\n\nSafe usage docs.",
+            "output": "This source documents safe usage.",
+            "domain": "demo",
+            "source_repo": "0ai-Cyberviser/demo",
+            "source_path": "README.md",
+            "source_digest": "abc123",
+            "license_id": "apache-2.0",
+            "quality_score": 0.9,
+            "safety_score": 1.0,
+        },
+        {
+            "id": "rec-2",
+            "instruction": "Summarize this test.",
+            "input": "Path: tests/test_demo.py",
+            "output": "This test validates the demo behavior.",
+            "domain": "demo",
+            "source_repo": "0ai-Cyberviser/demo",
+            "source_path": "tests/test_demo.py",
+            "source_digest": "def456",
+            "license_id": "apache-2.0",
+        },
+    ]
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_export_format_names():
+    assert set(export_format_names()) == {"chatml", "alpaca", "sharegpt"}
+
+
+def test_chatml_convert_record_has_messages(tmp_path: Path):
+    record = _read_jsonl(_dataset(tmp_path))[0]
+    converted = ModelExporter().convert_record(record, "chatml")
+    assert converted["messages"][0]["role"] == "system"
+    assert converted["messages"][1]["role"] == "user"
+    assert converted["messages"][2]["role"] == "assistant"
+
+
+def test_alpaca_convert_record_has_fields(tmp_path: Path):
+    record = _read_jsonl(_dataset(tmp_path))[0]
+    converted = ModelExporter().convert_record(record, "alpaca")
+    assert converted["instruction"] == "Explain this source."
+    assert "input" in converted
+    assert converted["output"]
+
+
+def test_sharegpt_convert_record_has_conversations(tmp_path: Path):
+    record = _read_jsonl(_dataset(tmp_path))[0]
+    converted = ModelExporter().convert_record(record, "sharegpt")
+    assert converted["conversations"][1]["from"] == "human"
+    assert converted["conversations"][2]["from"] == "gpt"
+
+
+def test_export_chatml_file(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "chatml.jsonl"
+    stats = ModelExporter().export_file(source, out, "chatml")
+    assert stats.ok
+    assert len(_read_jsonl(out)) == 2
+    assert "messages" in _read_jsonl(out)[0]
+
+
+def test_export_alpaca_file(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "alpaca.jsonl"
+    stats = ModelExporter().export_file(source, out, "alpaca")
+    assert stats.ok
+    assert "instruction" in _read_jsonl(out)[0]
+
+
+def test_export_sharegpt_file(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "sharegpt.jsonl"
+    stats = ModelExporter().export_file(source, out, "sharegpt")
+    assert stats.ok
+    assert "conversations" in _read_jsonl(out)[0]
+
+
+def test_export_limit(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "limited.jsonl"
+    stats = ModelExporter().export_file(source, out, "alpaca", limit=1)
+    assert stats.records_written == 1
+    assert len(_read_jsonl(out)) == 1
+
+
+def test_export_without_metadata(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "plain.jsonl"
+    ModelExporter(include_metadata=False).export_file(source, out, "alpaca")
+    assert "metadata" not in _read_jsonl(out)[0]
+
+
+def test_invalid_record_reports_issue(tmp_path: Path):
+    source = tmp_path / "bad.jsonl"
+    source.write_text(json.dumps({"instruction": "x", "output": ""}) + "\n", encoding="utf-8")
+    out = tmp_path / "out.jsonl"
+    stats = ModelExporter().export_file(source, out, "chatml")
+    assert not stats.ok
+    assert stats.issues
+
+
+def test_validate_chatml_export(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "chatml.jsonl"
+    ModelExporter().export_file(source, out, "chatml")
+    report = ModelExporter().validate_export(out, "chatml")
+    assert report.ok
+    assert report.records == 2
+
+
+def test_validate_alpaca_export(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "alpaca.jsonl"
+    ModelExporter().export_file(source, out, "alpaca")
+    assert ModelExporter().validate_export(out, "alpaca").ok
+
+
+def test_validate_sharegpt_export(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "sharegpt.jsonl"
+    ModelExporter().export_file(source, out, "sharegpt")
+    assert ModelExporter().validate_export(out, "sharegpt").ok
+
+
+def test_validate_bad_chatml_export(tmp_path: Path):
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text(json.dumps({"messages": [{"role": "user"}]}) + "\n", encoding="utf-8")
+    report = ModelExporter().validate_export(bad, "chatml")
+    assert not report.ok
+    assert report.issues
+
+
+def test_cli_export_formats(capsys):
+    rc = main(["export-formats"])
+    assert rc == 0
+    assert "chatml" in capsys.readouterr().out
+
+
+def test_cli_export_chatml(tmp_path: Path, capsys):
+    source = _dataset(tmp_path)
+    out = tmp_path / "chatml.jsonl"
+    rc = main(["export", "--source", str(source), "--format", "chatml", "--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    assert '"records_written": 2' in capsys.readouterr().out
+
+
+def test_cli_export_alpaca_no_metadata(tmp_path: Path):
+    source = _dataset(tmp_path)
+    out = tmp_path / "alpaca.jsonl"
+    rc = main(["export", "--source", str(source), "--format", "alpaca", "--output", str(out), "--no-metadata"])
+    assert rc == 0
+    assert "metadata" not in _read_jsonl(out)[0]
+
+
+def test_cli_validate_export(tmp_path: Path, capsys):
+    source = _dataset(tmp_path)
+    out = tmp_path / "sharegpt.jsonl"
+    main(["export", "--source", str(source), "--format", "sharegpt", "--output", str(out)])
+    rc = main(["validate-export", "--format", "sharegpt", "--path", str(out)])
+    assert rc == 0
+    assert '"ok": true' in capsys.readouterr().out


### PR DESCRIPTION
Adds local-only model exporter profiles for ChatML, Alpaca, and ShareGPT, including export validation, CLI commands, docs, CI, and tests.

Safety:
- Local-only.
- Does not train models.
- Does not contact APIs.
- Does not upload datasets.
- Preserves provenance metadata by default.
- Requires dataset review before downstream training.