### PR TITLE
feat: add scheduled dataset update PR workflow and diff review reports

### DIFF
--- a/.github/workflows/diff-review.yml
+++ b/.github/workflows/diff-review.yml
@@ -1,0 +1,32 @@
+name: PeachTree Diff Review CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/peachtree/diff_review.py"
+      - "src/peachtree/scheduler.py"
+      - "src/peachtree/cli.py"
+      - "tests/test_diff_review.py"
+      - "docs/SCHEDULED_UPDATES.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diff-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - run: pytest -q tests/test_diff_review.py
+      - run: pytest -q

--- a/.github/workflows/peachtree-dataset-update.yml
+++ b/.github/workflows/peachtree-dataset-update.yml
@@ -1,0 +1,79 @@
+name: PeachTree Dataset Update PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo_path:
+        description: "Local repo path after checkout"
+        required: false
+        default: "."
+      repo_name:
+        description: "Repository name for provenance"
+        required: false
+        default: "0ai-Cyberviser/PeachTree"
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dataset-update-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PeachTree
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Generate update plan
+        run: |
+          mkdir -p data/manifests reports
+          peachtree update-plan             --repo "${{ github.event.inputs.repo_path || '.' }}"             --repo-name "${{ github.event.inputs.repo_name || github.repository }}"             --output data/manifests/update-plan.json             --markdown-output reports/update-plan.md
+
+      - name: Build candidate dataset
+        run: |
+          SAFE_REPO_NAME="$(echo "${{ github.event.inputs.repo_name || github.repository }}" | sed 's#/#__#g')"
+          peachtree ingest-local             --repo "${{ github.event.inputs.repo_path || '.' }}"             --repo-name "${{ github.event.inputs.repo_name || github.repository }}"             --output "data/raw/${SAFE_REPO_NAME}.jsonl"
+          peachtree build             --source "data/raw/${SAFE_REPO_NAME}.jsonl"             --dataset "data/datasets/${SAFE_REPO_NAME}-instruct.jsonl"             --manifest "data/manifests/${SAFE_REPO_NAME}.json"             --domain "${SAFE_REPO_NAME}"
+          peachtree audit --dataset "data/datasets/${SAFE_REPO_NAME}-instruct.jsonl"
+
+      - name: Generate review report
+        run: |
+          peachtree review-report             --plan data/manifests/update-plan.json             --output reports/update-review.json
+
+      - name: Upload review artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: peachtree-dataset-update-review
+          path: |
+            data/manifests/*.json
+            data/datasets/*.jsonl
+            reports/*.md
+            reports/*.json
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: peachtree/dataset-update
+          commit-message: "chore: update PeachTree datasets"
+          title: "chore: update PeachTree datasets"
+          body: |
+            Automated PeachTree dataset update candidate.
+
+            Review required before merge:
+            - Dataset manifests
+            - Dataset JSONL changes
+            - Review reports
+            - Provenance warnings
+
+            This workflow does not train models or upload datasets.
+          labels: dataset, peachtree, review-required

--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ peachtree validate-export --format chatml --path data/exports/peachfuzz-chatml.j
 ```
 
 Exporters are local-only and preserve provenance metadata by default.
+
+
+## Scheduled dataset update PR workflow
+
+PeachTree v0.5.0 adds review-first scheduled update tooling.
+
+```bash
+peachtree update-plan --repo ~/peachfuzz --repo-name 0ai-Cyberviser/peachfuzz --output data/manifests/update-plan.json
+peachtree diff --baseline data/baseline/old.jsonl --candidate data/datasets/new.jsonl --format markdown
+peachtree review-report --plan data/manifests/update-plan.json --output reports/update-review.json
+```
+
+The included GitHub Actions workflow opens pull requests for dataset updates. It does not train models, upload datasets, or push directly to `main`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,4 +23,5 @@
 - Exporters: ChatML, Alpaca, ShareGPT ✅
 
 ## v0.5.0
-- GitHub Actions scheduled dataset update PR workflow
+- GitHub Actions scheduled dataset update PR workflow ✅
+- Dataset diff review reports ✅

--- a/docs/SCHEDULED_UPDATES.md
+++ b/docs/SCHEDULED_UPDATES.md
@@ -1,0 +1,63 @@
+# Scheduled Dataset Update PR Workflow
+
+PeachTree v0.5.0 adds review-first scheduled dataset update tooling.
+
+The goal is to keep datasets fresh without silently changing model training inputs.
+
+## New CLI
+
+```bash
+peachtree update-plan
+peachtree diff
+peachtree review-report
+```
+
+## Create an update plan
+
+```bash
+peachtree update-plan \
+  --repo ~/peachfuzz \
+  --repo-name 0ai-Cyberviser/peachfuzz \
+  --output data/manifests/update-plan.json \
+  --markdown-output reports/update-plan.md
+```
+
+## Compare datasets
+
+```bash
+peachtree diff \
+  --baseline data/baseline/peachfuzz-instruct.jsonl \
+  --candidate data/datasets/peachfuzz-instruct.jsonl \
+  --format markdown \
+  --json-output reports/dataset-diff.json \
+  --markdown-output reports/dataset-diff.md
+```
+
+## Generate a review report
+
+```bash
+peachtree review-report \
+  --plan data/manifests/update-plan.json \
+  --output reports/update-review.json
+```
+
+## CI workflow behavior
+
+`.github/workflows/peachtree-dataset-update.yml` is intentionally PR-based:
+
+1. Checkout repository.
+2. Install PeachTree.
+3. Generate update plan.
+4. Build/update datasets.
+5. Generate diff and review reports.
+6. Upload reports as artifacts.
+7. Open a pull request for human review.
+
+## Safety model
+
+- no model training
+- no dataset upload
+- no direct push to `main`
+- no public GitHub scraping
+- all changes are reviewed through pull requests
+- reports include added, removed, changed records and provenance warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peachtree-ai"
-version = "0.4.0"
+version = "0.5.0"
 description = "Recursive learning-tree dataset engine for safe AI model training pipelines"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/peachtree/__init__.py
+++ b/src/peachtree/__init__.py
@@ -5,6 +5,8 @@ from .github_owned import OwnedGitHubConnector, OwnedRepo
 from .dependency_graph import DependencyGraphBuilder, DependencyGraph
 from .lineage import DatasetLineageBuilder, DatasetLineage
 from .exporters import ModelExporter, export_format_names
+from .diff_review import DatasetDiffReviewer, DatasetDiff
+from .scheduler import UpdatePlanBuilder, ScheduledUpdatePlan
 from .safety import SafetyGate
 
 __all__ = [
@@ -23,6 +25,10 @@ __all__ = [
     "DatasetLineage",
     "ModelExporter",
     "export_format_names",
+    "DatasetDiffReviewer",
+    "DatasetDiff",
+    "UpdatePlanBuilder",
+    "ScheduledUpdatePlan",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/peachtree/builder.py
+++ b/src/peachtree/builder.py
@@ -55,7 +55,7 @@ class DatasetBuilder:
             record_count=len(records),
             source_count=len(sources),
             domain=self.domain,
-            builder_version="0.4.0",
+            builder_version="0.5.0",
             source_digests=tuple(sorted({source.digest for source in sources})),
             policy={"secret_filtering": True, "license_filtering": True, "provenance_required": True},
         )

--- a/src/peachtree/cli.py
+++ b/src/peachtree/cli.py
@@ -13,6 +13,8 @@ from .github_owned import OwnedGitHubConnector
 from .dependency_graph import DependencyGraphBuilder
 from .lineage import DatasetLineageBuilder
 from .exporters import ModelExporter, export_format_names
+from .diff_review import DatasetDiffReviewer
+from .scheduler import UpdatePlanBuilder
 
 
 def run_plan(args: argparse.Namespace) -> int:
@@ -170,6 +172,57 @@ def run_validate_export(args: argparse.Namespace) -> int:
     print(report.to_json())
     return 0 if report.ok else 1
 
+
+
+def run_diff(args: argparse.Namespace) -> int:
+    reviewer = DatasetDiffReviewer()
+    diff = reviewer.compare(args.baseline, args.candidate)
+    if args.json_output or args.markdown_output:
+        reviewer.write_reports(
+            diff,
+            args.json_output or "reports/dataset-diff.json",
+            args.markdown_output or "reports/dataset-diff.md",
+        )
+    if args.format == "markdown":
+        print(diff.to_markdown())
+    else:
+        print(diff.to_json())
+    return 0 if not args.fail_on_review or not diff.review_required else 2
+
+
+def run_update_plan(args: argparse.Namespace) -> int:
+    builder = UpdatePlanBuilder()
+    plan = builder.default_plan(args.repo, args.repo_name, name=args.name)
+    if args.output or args.markdown_output:
+        builder.write_plan(plan, args.output or "data/manifests/update-plan.json", args.markdown_output)
+    if args.format == "markdown":
+        print(plan.to_markdown())
+    else:
+        print(plan.to_json())
+    return 0
+
+
+def run_review_report(args: argparse.Namespace) -> int:
+    builder = UpdatePlanBuilder()
+    plan = builder.read_plan(args.plan)
+    commands = builder.command_preview(plan)
+    report = {
+        "plan": plan.to_dict(),
+        "commands": commands,
+        "safety": {
+            "review_required": plan.review_required,
+            "opens_pull_request": plan.open_pull_request,
+            "does_not_train_models": True,
+            "does_not_upload_datasets": True,
+        },
+    }
+    content = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(content + "\n", encoding="utf-8")
+    print(content)
+    return 0
+
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="peachtree", description="Recursive learning-tree dataset engine")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -255,6 +308,29 @@ def make_parser() -> argparse.ArgumentParser:
     validate_export.add_argument("--path", required=True)
     validate_export.add_argument("--format", choices=list(export_format_names()), required=True)
     validate_export.set_defaults(func=run_validate_export)
+
+    diff = sub.add_parser("diff", help="compare baseline and candidate dataset JSONL files")
+    diff.add_argument("--baseline", required=True)
+    diff.add_argument("--candidate", required=True)
+    diff.add_argument("--format", choices=["json", "markdown"], default="json")
+    diff.add_argument("--json-output")
+    diff.add_argument("--markdown-output")
+    diff.add_argument("--fail-on-review", action="store_true")
+    diff.set_defaults(func=run_diff)
+
+    update_plan = sub.add_parser("update-plan", help="create a scheduled dataset update plan")
+    update_plan.add_argument("--repo", required=True, help="local repository path used by CI checkout or local run")
+    update_plan.add_argument("--repo-name", required=True)
+    update_plan.add_argument("--name", default="peachtree-dataset-update")
+    update_plan.add_argument("--format", choices=["json", "markdown"], default="json")
+    update_plan.add_argument("--output")
+    update_plan.add_argument("--markdown-output")
+    update_plan.set_defaults(func=run_update_plan)
+
+    review_report = sub.add_parser("review-report", help="render a dataset update review report from a plan")
+    review_report.add_argument("--plan", required=True)
+    review_report.add_argument("--output")
+    review_report.set_defaults(func=run_review_report)
 
     policy = sub.add_parser("policy", help="show collection safety policy")
     policy.set_defaults(func=run_policy)

--- a/src/peachtree/diff_review.py
+++ b/src/peachtree/diff_review.py
@@ -1,0 +1,222 @@
+"""Dataset diff and review reports for PeachTree.
+
+This module compares reviewed PeachTree dataset JSONL files and produces
+human-readable change reports before any downstream training run.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class DatasetRecordSummary:
+    record_id: str
+    digest: str
+    source_repo: str = "unknown"
+    source_path: str = "unknown"
+    source_digest: str = "unknown"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DatasetFingerprint:
+    path: str
+    file_digest: str
+    record_count: int
+    record_ids: tuple[str, ...]
+    source_repos: tuple[str, ...]
+    source_paths: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DatasetDiff:
+    baseline_path: str
+    candidate_path: str
+    baseline_count: int
+    candidate_count: int
+    added_ids: tuple[str, ...] = field(default_factory=tuple)
+    removed_ids: tuple[str, ...] = field(default_factory=tuple)
+    changed_ids: tuple[str, ...] = field(default_factory=tuple)
+    unchanged_count: int = 0
+    new_source_repos: tuple[str, ...] = field(default_factory=tuple)
+    removed_source_repos: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def record_delta(self) -> int:
+        return self.candidate_count - self.baseline_count
+
+    @property
+    def risk_score(self) -> int:
+        score = 0
+        score += min(len(self.added_ids), 25)
+        score += min(len(self.removed_ids) * 2, 40)
+        score += min(len(self.changed_ids), 25)
+        score += min(len(self.new_source_repos) * 5, 20)
+        score += len(self.warnings) * 10
+        return min(score, 100)
+
+    @property
+    def review_required(self) -> bool:
+        return bool(self.added_ids or self.removed_ids or self.changed_ids or self.new_source_repos or self.warnings)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["record_delta"] = self.record_delta
+        data["risk_score"] = self.risk_score
+        data["review_required"] = self.review_required
+        return data
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# PeachTree Dataset Diff Review",
+            "",
+            f"- Baseline: `{self.baseline_path}`",
+            f"- Candidate: `{self.candidate_path}`",
+            f"- Baseline records: `{self.baseline_count}`",
+            f"- Candidate records: `{self.candidate_count}`",
+            f"- Record delta: `{self.record_delta}`",
+            f"- Risk score: `{self.risk_score}/100`",
+            f"- Review required: `{'yes' if self.review_required else 'no'}`",
+            "",
+            "## Change Summary",
+            "",
+            f"- Added records: `{len(self.added_ids)}`",
+            f"- Removed records: `{len(self.removed_ids)}`",
+            f"- Changed records: `{len(self.changed_ids)}`",
+            f"- New source repos: `{len(self.new_source_repos)}`",
+            f"- Removed source repos: `{len(self.removed_source_repos)}`",
+        ]
+        if self.warnings:
+            lines += ["", "## Warnings", ""]
+            lines.extend(f"- {warning}" for warning in self.warnings)
+        lines += ["", "## Added IDs", ""]
+        if self.added_ids:
+            lines.extend(f"- `{value}`" for value in self.added_ids[:100])
+        else:
+            lines.append("- None")
+        lines += ["", "## Removed IDs", ""]
+        if self.removed_ids:
+            lines.extend(f"- `{value}`" for value in self.removed_ids[:100])
+        else:
+            lines.append("- None")
+        lines += ["", "## Changed IDs", ""]
+        if self.changed_ids:
+            lines.extend(f"- `{value}`" for value in self.changed_ids[:100])
+        else:
+            lines.append("- None")
+        return "\n".join(lines)
+
+
+class DatasetDiffReviewer:
+    """Compares PeachTree datasets and emits reviewable reports."""
+
+    def fingerprint(self, dataset_path: str | Path) -> DatasetFingerprint:
+        path = Path(dataset_path)
+        summaries = self._summaries(path)
+        return DatasetFingerprint(
+            path=str(path),
+            file_digest=sha256_bytes(path.read_bytes()) if path.exists() else "",
+            record_count=len(summaries),
+            record_ids=tuple(sorted(summaries)),
+            source_repos=tuple(sorted({item.source_repo for item in summaries.values()})),
+            source_paths=tuple(sorted({item.source_path for item in summaries.values()})),
+        )
+
+    def compare(self, baseline_path: str | Path, candidate_path: str | Path) -> DatasetDiff:
+        baseline = self._summaries(Path(baseline_path))
+        candidate = self._summaries(Path(candidate_path))
+        baseline_ids = set(baseline)
+        candidate_ids = set(candidate)
+        added = tuple(sorted(candidate_ids - baseline_ids))
+        removed = tuple(sorted(baseline_ids - candidate_ids))
+        shared = baseline_ids & candidate_ids
+        changed = tuple(sorted(record_id for record_id in shared if baseline[record_id].digest != candidate[record_id].digest))
+        unchanged = len(shared) - len(changed)
+        baseline_repos = {item.source_repo for item in baseline.values()}
+        candidate_repos = {item.source_repo for item in candidate.values()}
+        warnings = self._warnings(baseline, candidate, added, removed, changed)
+        return DatasetDiff(
+            baseline_path=str(baseline_path),
+            candidate_path=str(candidate_path),
+            baseline_count=len(baseline),
+            candidate_count=len(candidate),
+            added_ids=added,
+            removed_ids=removed,
+            changed_ids=changed,
+            unchanged_count=unchanged,
+            new_source_repos=tuple(sorted(candidate_repos - baseline_repos)),
+            removed_source_repos=tuple(sorted(baseline_repos - candidate_repos)),
+            warnings=tuple(warnings),
+        )
+
+    def write_reports(self, diff: DatasetDiff, json_output: str | Path, markdown_output: str | Path) -> tuple[Path, Path]:
+        json_path = Path(json_output)
+        md_path = Path(markdown_output)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(diff.to_json() + "\n", encoding="utf-8")
+        md_path.write_text(diff.to_markdown() + "\n", encoding="utf-8")
+        return json_path, md_path
+
+    def _summaries(self, path: Path) -> dict[str, DatasetRecordSummary]:
+        if not path.exists():
+            return {}
+        summaries: dict[str, DatasetRecordSummary] = {}
+        for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                record = {"id": f"invalid-json-line-{index}", "_raw": line}
+            if not isinstance(record, dict):
+                record = {"id": f"invalid-record-line-{index}", "_raw": repr(record)}
+            record_id = str(record.get("id") or sha256_bytes(json.dumps(record, sort_keys=True).encode())[:16])
+            digest = sha256_bytes(json.dumps(record, sort_keys=True, ensure_ascii=False).encode("utf-8"))
+            summaries[record_id] = DatasetRecordSummary(
+                record_id=record_id,
+                digest=digest,
+                source_repo=str(record.get("source_repo", "unknown")),
+                source_path=str(record.get("source_path", "unknown")),
+                source_digest=str(record.get("source_digest", "unknown")),
+            )
+        return summaries
+
+    @staticmethod
+    def _warnings(
+        baseline: dict[str, DatasetRecordSummary],
+        candidate: dict[str, DatasetRecordSummary],
+        added: tuple[str, ...],
+        removed: tuple[str, ...],
+        changed: tuple[str, ...],
+    ) -> list[str]:
+        warnings: list[str] = []
+        if not candidate:
+            warnings.append("candidate dataset is empty")
+        if len(removed) > len(baseline) * 0.25 and baseline:
+            warnings.append("more than 25% of baseline records were removed")
+        if len(added) > max(50, len(baseline) * 0.5):
+            warnings.append("large number of records added; manual review recommended")
+        candidate_unknown = [record for record in candidate.values() if record.source_repo == "unknown"]
+        if candidate_unknown:
+            warnings.append("candidate contains records without source_repo provenance")
+        if changed:
+            warnings.append("existing record IDs changed content")
+        return warnings

--- a/src/peachtree/scheduler.py
+++ b/src/peachtree/scheduler.py
@@ -1,0 +1,145 @@
+"""Scheduled dataset update planning for PeachTree.
+
+This module generates review-first update plans. It does not run background
+jobs itself and does not push data without an explicit CI workflow.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DatasetUpdateTarget:
+    name: str
+    repo_path: str
+    repo_name: str
+    raw_output: str
+    dataset_output: str
+    manifest_output: str
+    domain: str
+    export_formats: tuple[str, ...] = ("chatml", "alpaca", "sharegpt")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ScheduledUpdatePlan:
+    name: str
+    cron: str
+    branch_prefix: str
+    targets: tuple[DatasetUpdateTarget, ...]
+    review_required: bool = True
+    open_pull_request: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# PeachTree Scheduled Dataset Update Plan",
+            "",
+            f"- Name: `{self.name}`",
+            f"- Cron: `{self.cron}`",
+            f"- Branch prefix: `{self.branch_prefix}`",
+            f"- Review required: `{'yes' if self.review_required else 'no'}`",
+            f"- Opens pull request: `{'yes' if self.open_pull_request else 'no'}`",
+            "",
+            "## Targets",
+            "",
+            "| Name | Repo Name | Repo Path | Dataset | Manifest | Exports |",
+            "|---|---|---|---|---|---|",
+        ]
+        for target in self.targets:
+            lines.append(
+                f"| `{target.name}` | `{target.repo_name}` | `{target.repo_path}` | `{target.dataset_output}` | `{target.manifest_output}` | `{', '.join(target.export_formats)}` |"
+            )
+        return "\n".join(lines)
+
+
+class UpdatePlanBuilder:
+    """Builds deterministic update plans for dataset-refresh PR workflows."""
+
+    def default_plan(self, repo_path: str, repo_name: str, name: str = "peachtree-dataset-update") -> ScheduledUpdatePlan:
+        safe_name = repo_name.replace("/", "__")
+        target = DatasetUpdateTarget(
+            name=safe_name,
+            repo_path=repo_path,
+            repo_name=repo_name,
+            raw_output=f"data/raw/{safe_name}.jsonl",
+            dataset_output=f"data/datasets/{safe_name}-instruct.jsonl",
+            manifest_output=f"data/manifests/{safe_name}.json",
+            domain=safe_name,
+        )
+        return ScheduledUpdatePlan(
+            name=name,
+            cron="17 3 * * 1",
+            branch_prefix="peachtree/dataset-update",
+            targets=(target,),
+        )
+
+    def write_plan(
+        self,
+        plan: ScheduledUpdatePlan,
+        json_output: str | Path,
+        markdown_output: str | Path | None = None,
+    ) -> tuple[Path, Path | None]:
+        json_path = Path(json_output)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(plan.to_json() + "\n", encoding="utf-8")
+        md_path: Path | None = None
+        if markdown_output:
+            md_path = Path(markdown_output)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(plan.to_markdown() + "\n", encoding="utf-8")
+        return json_path, md_path
+
+    def read_plan(self, path: str | Path) -> ScheduledUpdatePlan:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        targets = tuple(
+            DatasetUpdateTarget(
+                name=target["name"],
+                repo_path=target["repo_path"],
+                repo_name=target["repo_name"],
+                raw_output=target["raw_output"],
+                dataset_output=target["dataset_output"],
+                manifest_output=target["manifest_output"],
+                domain=target["domain"],
+                export_formats=tuple(target.get("export_formats", ("chatml", "alpaca", "sharegpt"))),
+            )
+            for target in data.get("targets", [])
+        )
+        return ScheduledUpdatePlan(
+            name=data["name"],
+            cron=data["cron"],
+            branch_prefix=data["branch_prefix"],
+            targets=targets,
+            review_required=bool(data.get("review_required", True)),
+            open_pull_request=bool(data.get("open_pull_request", True)),
+        )
+
+    @staticmethod
+    def command_preview(plan: ScheduledUpdatePlan) -> list[str]:
+        commands: list[str] = []
+        for target in plan.targets:
+            commands.extend(
+                [
+                    f"peachtree ingest-local --repo {target.repo_path} --repo-name {target.repo_name} --output {target.raw_output}",
+                    f"peachtree build --source {target.raw_output} --dataset {target.dataset_output} --manifest {target.manifest_output} --domain {target.domain}",
+                    f"peachtree audit --dataset {target.dataset_output}",
+                ]
+            )
+            for export_format in target.export_formats:
+                commands.append(
+                    f"peachtree export --source {target.dataset_output} --format {export_format} --output data/exports/{target.name}-{export_format}.jsonl"
+                )
+                commands.append(
+                    f"peachtree validate-export --format {export_format} --path data/exports/{target.name}-{export_format}.jsonl"
+                )
+        return commands

--- a/tests/test_diff_review.py
+++ b/tests/test_diff_review.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+import json
+
+from peachtree.cli import main
+from peachtree.diff_review import DatasetDiffReviewer
+from peachtree.scheduler import UpdatePlanBuilder
+
+
+def _write_dataset(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n", encoding="utf-8")
+    return path
+
+
+def test_dataset_fingerprint_counts_records(tmp_path: Path):
+    dataset = _write_dataset(
+        tmp_path / "dataset.jsonl",
+        [{"id": "a", "source_repo": "repo", "source_path": "README.md", "source_digest": "d"}],
+    )
+    fp = DatasetDiffReviewer().fingerprint(dataset)
+    assert fp.record_count == 1
+    assert fp.source_repos == ("repo",)
+
+
+def test_dataset_diff_detects_added_removed_changed(tmp_path: Path):
+    baseline = _write_dataset(
+        tmp_path / "old.jsonl",
+        [
+            {"id": "same", "instruction": "i", "output": "o", "source_repo": "repo", "source_path": "a.md"},
+            {"id": "removed", "instruction": "i", "output": "o", "source_repo": "repo", "source_path": "b.md"},
+            {"id": "changed", "instruction": "i", "output": "old", "source_repo": "repo", "source_path": "c.md"},
+        ],
+    )
+    candidate = _write_dataset(
+        tmp_path / "new.jsonl",
+        [
+            {"id": "same", "instruction": "i", "output": "o", "source_repo": "repo", "source_path": "a.md"},
+            {"id": "changed", "instruction": "i", "output": "new", "source_repo": "repo", "source_path": "c.md"},
+            {"id": "added", "instruction": "i", "output": "o", "source_repo": "new/repo", "source_path": "d.md"},
+        ],
+    )
+    diff = DatasetDiffReviewer().compare(baseline, candidate)
+    assert diff.added_ids == ("added",)
+    assert diff.removed_ids == ("removed",)
+    assert diff.changed_ids == ("changed",)
+    assert diff.new_source_repos == ("new/repo",)
+    assert diff.review_required
+
+
+def test_dataset_diff_markdown_contains_summary(tmp_path: Path):
+    baseline = _write_dataset(tmp_path / "old.jsonl", [{"id": "a", "output": "old", "source_repo": "repo"}])
+    candidate = _write_dataset(tmp_path / "new.jsonl", [{"id": "a", "output": "new", "source_repo": "repo"}])
+    markdown = DatasetDiffReviewer().compare(baseline, candidate).to_markdown()
+    assert "PeachTree Dataset Diff Review" in markdown
+    assert "Changed records" in markdown
+
+
+def test_dataset_diff_writes_reports(tmp_path: Path):
+    baseline = _write_dataset(tmp_path / "old.jsonl", [{"id": "a", "output": "old", "source_repo": "repo"}])
+    candidate = _write_dataset(tmp_path / "new.jsonl", [{"id": "a", "output": "new", "source_repo": "repo"}])
+    reviewer = DatasetDiffReviewer()
+    diff = reviewer.compare(baseline, candidate)
+    json_path, md_path = reviewer.write_reports(diff, tmp_path / "diff.json", tmp_path / "diff.md")
+    assert json_path.exists()
+    assert md_path.exists()
+    assert json.loads(json_path.read_text(encoding="utf-8"))["review_required"] is True
+
+
+def test_update_plan_default_shape():
+    plan = UpdatePlanBuilder().default_plan("~/peachfuzz", "0ai-Cyberviser/peachfuzz")
+    assert plan.targets[0].repo_name == "0ai-Cyberviser/peachfuzz"
+    assert plan.review_required
+    assert "0ai-Cyberviser__peachfuzz" in plan.targets[0].dataset_output
+
+
+def test_update_plan_markdown_mentions_targets():
+    plan = UpdatePlanBuilder().default_plan("~/peachfuzz", "0ai-Cyberviser/peachfuzz")
+    markdown = plan.to_markdown()
+    assert "Scheduled Dataset Update Plan" in markdown
+    assert "0ai-Cyberviser/peachfuzz" in markdown
+
+
+def test_update_plan_write_and_read(tmp_path: Path):
+    builder = UpdatePlanBuilder()
+    plan = builder.default_plan("~/peachfuzz", "0ai-Cyberviser/peachfuzz")
+    path, md = builder.write_plan(plan, tmp_path / "plan.json", tmp_path / "plan.md")
+    loaded = builder.read_plan(path)
+    assert loaded.name == plan.name
+    assert md is not None and md.exists()
+
+
+def test_update_plan_command_preview():
+    plan = UpdatePlanBuilder().default_plan("~/peachfuzz", "0ai-Cyberviser/peachfuzz")
+    commands = UpdatePlanBuilder.command_preview(plan)
+    assert any("peachtree ingest-local" in command for command in commands)
+    assert any("validate-export" in command for command in commands)
+
+
+def test_cli_diff_json(tmp_path: Path, capsys):
+    baseline = _write_dataset(tmp_path / "old.jsonl", [{"id": "a", "output": "old", "source_repo": "repo"}])
+    candidate = _write_dataset(tmp_path / "new.jsonl", [{"id": "b", "output": "new", "source_repo": "repo"}])
+    rc = main(["diff", "--baseline", str(baseline), "--candidate", str(candidate)])
+    assert rc == 0
+    assert '"review_required": true' in capsys.readouterr().out
+
+
+def test_cli_diff_markdown_outputs_files(tmp_path: Path):
+    baseline = _write_dataset(tmp_path / "old.jsonl", [{"id": "a", "output": "old", "source_repo": "repo"}])
+    candidate = _write_dataset(tmp_path / "new.jsonl", [{"id": "b", "output": "new", "source_repo": "repo"}])
+    rc = main([
+        "diff",
+        "--baseline", str(baseline),
+        "--candidate", str(candidate),
+        "--format", "markdown",
+        "--json-output", str(tmp_path / "diff.json"),
+        "--markdown-output", str(tmp_path / "diff.md"),
+    ])
+    assert rc == 0
+    assert (tmp_path / "diff.json").exists()
+    assert (tmp_path / "diff.md").exists()
+
+
+def test_cli_update_plan(tmp_path: Path, capsys):
+    rc = main([
+        "update-plan",
+        "--repo", "~/peachfuzz",
+        "--repo-name", "0ai-Cyberviser/peachfuzz",
+        "--output", str(tmp_path / "plan.json"),
+        "--markdown-output", str(tmp_path / "plan.md"),
+    ])
+    assert rc == 0
+    assert (tmp_path / "plan.json").exists()
+    assert '"review_required": true' in capsys.readouterr().out
+
+
+def test_cli_review_report(tmp_path: Path, capsys):
+    plan_path = tmp_path / "plan.json"
+    main([
+        "update-plan",
+        "--repo", "~/peachfuzz",
+        "--repo-name", "0ai-Cyberviser/peachfuzz",
+        "--output", str(plan_path),
+    ])
+    rc = main(["review-report", "--plan", str(plan_path), "--output", str(tmp_path / "review.json")])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"does_not_train_models": true' in out
+    assert (tmp_path / "review.json").exists()


### PR DESCRIPTION
Adds review-first scheduled dataset update tooling, dataset diff reports, update plans, review reports, CLI commands, docs, CI, and a PR-based GitHub Actions workflow.

Safety:
- Does not train models.
- Does not upload datasets.
- Does not push directly to main.
- Does not scrape public GitHub.
- Opens reviewable pull requests for dataset updates.
- Includes added/removed/changed record summaries and provenance warnings.