### PR TITLE
feat: add dataset quality scoring, deduplication, and readiness gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,32 @@
+name: PeachTree Quality Gates CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/peachtree/quality.py"
+      - "src/peachtree/dedup.py"
+      - "src/peachtree/cli.py"
+      - "tests/test_quality.py"
+      - "docs/QUALITY_GATES.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - run: pytest -q tests/test_quality.py
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -136,3 +136,16 @@ peachtree review-report --plan data/manifests/update-plan.json --output reports/
 ```
 
 The included GitHub Actions workflow opens pull requests for dataset updates. It does not train models, upload datasets, or push directly to `main`.
+
+
+## Dataset quality gates
+
+PeachTree v0.6.0 adds quality scoring, deterministic deduplication, and training readiness checks.
+
+```bash
+peachtree score --dataset data/datasets/peachfuzz-instruct.jsonl --markdown-output reports/quality.md
+peachtree dedup --source data/datasets/peachfuzz-instruct.jsonl --output data/datasets/peachfuzz-deduped.jsonl
+peachtree readiness --dataset data/datasets/peachfuzz-deduped.jsonl --output reports/readiness.json
+```
+
+These commands are local-only and do not train models or upload datasets.

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -1,0 +1,73 @@
+# Dataset Quality Scoring, Deduplication, and Training Readiness Gates
+
+PeachTree v0.6.0 adds local-only data governance gates before model training.
+
+## New CLI
+
+```bash
+peachtree score
+peachtree dedup
+peachtree readiness
+```
+
+## Score a dataset
+
+```bash
+peachtree score \
+  --dataset data/datasets/peachfuzz-instruct.jsonl \
+  --format markdown \
+  --json-output reports/quality.json \
+  --markdown-output reports/quality.md
+```
+
+Quality scoring checks:
+
+- instruction presence and useful length
+- output presence and useful length
+- source repository provenance
+- source path provenance
+- source digest
+- license metadata
+- safety score
+- builder quality score
+
+## Deduplicate a dataset
+
+```bash
+peachtree dedup \
+  --source data/datasets/peachfuzz-instruct.jsonl \
+  --output data/datasets/peachfuzz-instruct-deduped.jsonl \
+  --report-json reports/dedup.json \
+  --report-markdown reports/dedup.md
+```
+
+Deduplication uses a deterministic normalized signature over:
+
+- instruction
+- input
+- output
+
+## Readiness gates
+
+```bash
+peachtree readiness \
+  --dataset data/datasets/peachfuzz-instruct-deduped.jsonl \
+  --output reports/readiness.json \
+  --fail-on-gate
+```
+
+Readiness combines:
+
+- quality score gate
+- failed-record ratio gate
+- provenance gate
+- duplicate-ratio gate
+- minimum record count gate
+
+## Safety model
+
+- local-only
+- no model training
+- no dataset upload
+- no public GitHub scraping
+- reports are designed for human review before downstream training

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,3 +25,9 @@
 ## v0.5.0
 - GitHub Actions scheduled dataset update PR workflow ✅
 - Dataset diff review reports ✅
+
+
+## v0.6.0
+- Dataset quality scoring ✅
+- Deterministic deduplication ✅
+- Training readiness gates ✅

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peachtree-ai"
-version = "0.5.0"
+version = "0.6.0"
 description = "Recursive learning-tree dataset engine for safe AI model training pipelines"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/peachtree/__init__.py
+++ b/src/peachtree/__init__.py
@@ -7,6 +7,8 @@ from .lineage import DatasetLineageBuilder, DatasetLineage
 from .exporters import ModelExporter, export_format_names
 from .diff_review import DatasetDiffReviewer, DatasetDiff
 from .scheduler import UpdatePlanBuilder, ScheduledUpdatePlan
+from .quality import DatasetQualityScorer, DatasetQualityReport
+from .dedup import DatasetDeduplicator, DedupReport
 from .safety import SafetyGate
 
 __all__ = [
@@ -29,6 +31,10 @@ __all__ = [
     "DatasetDiff",
     "UpdatePlanBuilder",
     "ScheduledUpdatePlan",
+    "DatasetQualityScorer",
+    "DatasetQualityReport",
+    "DatasetDeduplicator",
+    "DedupReport",
 ]
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/peachtree/builder.py
+++ b/src/peachtree/builder.py
@@ -55,7 +55,7 @@ class DatasetBuilder:
             record_count=len(records),
             source_count=len(sources),
             domain=self.domain,
-            builder_version="0.5.0",
+            builder_version="0.6.0",
             source_digests=tuple(sorted({source.digest for source in sources})),
             policy={"secret_filtering": True, "license_filtering": True, "provenance_required": True},
         )

--- a/src/peachtree/cli.py
+++ b/src/peachtree/cli.py
@@ -15,6 +15,8 @@ from .lineage import DatasetLineageBuilder
 from .exporters import ModelExporter, export_format_names
 from .diff_review import DatasetDiffReviewer
 from .scheduler import UpdatePlanBuilder
+from .quality import DatasetQualityScorer
+from .dedup import DatasetDeduplicator
 
 
 def run_plan(args: argparse.Namespace) -> int:
@@ -223,6 +225,78 @@ def run_review_report(args: argparse.Namespace) -> int:
     print(content)
     return 0
 
+
+
+def run_score(args: argparse.Namespace) -> int:
+    scorer = DatasetQualityScorer(
+        min_record_score=args.min_record_score,
+        min_average_score=args.min_average_score,
+        max_failed_ratio=args.max_failed_ratio,
+        min_records=args.min_records,
+    )
+    report = scorer.score_dataset(args.dataset)
+    if args.json_output or args.markdown_output:
+        scorer.write_report(
+            report,
+            args.json_output or "reports/quality-score.json",
+            args.markdown_output,
+        )
+    if args.format == "markdown":
+        print(report.to_markdown())
+    else:
+        print(report.to_json(include_records=not args.summary_only))
+    return 0 if not args.fail_on_gate or report.gate_passed else 2
+
+
+def run_dedup(args: argparse.Namespace) -> int:
+    deduplicator = DatasetDeduplicator()
+    report = deduplicator.deduplicate(args.source, args.output, write_output=True)
+    if args.report_json or args.report_markdown:
+        deduplicator.write_report(
+            report,
+            args.report_json or "reports/dedup.json",
+            args.report_markdown,
+        )
+    if args.format == "markdown":
+        print(report.to_markdown())
+    else:
+        print(report.to_json())
+    return 0
+
+
+def run_readiness(args: argparse.Namespace) -> int:
+    scorer = DatasetQualityScorer(
+        min_record_score=args.min_record_score,
+        min_average_score=args.min_average_score,
+        max_failed_ratio=args.max_failed_ratio,
+        min_records=args.min_records,
+    )
+    quality_report = scorer.score_dataset(args.dataset)
+    dedup_report = DatasetDeduplicator().analyze(args.dataset)
+    readiness = {
+        "dataset": args.dataset,
+        "ready": quality_report.gate_passed and dedup_report.duplicate_ratio <= args.max_duplicate_ratio,
+        "quality": quality_report.to_dict(include_records=False),
+        "deduplication": dedup_report.to_dict(),
+        "gates": {
+            "quality_gate_passed": quality_report.gate_passed,
+            "max_duplicate_ratio": args.max_duplicate_ratio,
+            "actual_duplicate_ratio": dedup_report.duplicate_ratio,
+            "duplicate_gate_passed": dedup_report.duplicate_ratio <= args.max_duplicate_ratio,
+        },
+        "safety": {
+            "does_not_train_models": True,
+            "does_not_upload_datasets": True,
+            "requires_human_review": True,
+        },
+    }
+    content = json.dumps(readiness, indent=2, sort_keys=True)
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(content + "\n", encoding="utf-8")
+    print(content)
+    return 0 if readiness["ready"] or not args.fail_on_gate else 2
+
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="peachtree", description="Recursive learning-tree dataset engine")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -331,6 +405,38 @@ def make_parser() -> argparse.ArgumentParser:
     review_report.add_argument("--plan", required=True)
     review_report.add_argument("--output")
     review_report.set_defaults(func=run_review_report)
+
+    score = sub.add_parser("score", help="score a PeachTree dataset for quality")
+    score.add_argument("--dataset", required=True)
+    score.add_argument("--format", choices=["json", "markdown"], default="json")
+    score.add_argument("--json-output")
+    score.add_argument("--markdown-output")
+    score.add_argument("--min-record-score", type=int, default=70)
+    score.add_argument("--min-average-score", type=int, default=80)
+    score.add_argument("--max-failed-ratio", type=float, default=0.10)
+    score.add_argument("--min-records", type=int, default=1)
+    score.add_argument("--summary-only", action="store_true")
+    score.add_argument("--fail-on-gate", action="store_true")
+    score.set_defaults(func=run_score)
+
+    dedup = sub.add_parser("dedup", help="deduplicate a PeachTree dataset")
+    dedup.add_argument("--source", required=True)
+    dedup.add_argument("--output", required=True)
+    dedup.add_argument("--format", choices=["json", "markdown"], default="json")
+    dedup.add_argument("--report-json")
+    dedup.add_argument("--report-markdown")
+    dedup.set_defaults(func=run_dedup)
+
+    readiness = sub.add_parser("readiness", help="evaluate dataset training readiness gates")
+    readiness.add_argument("--dataset", required=True)
+    readiness.add_argument("--output")
+    readiness.add_argument("--min-record-score", type=int, default=70)
+    readiness.add_argument("--min-average-score", type=int, default=80)
+    readiness.add_argument("--max-failed-ratio", type=float, default=0.10)
+    readiness.add_argument("--min-records", type=int, default=1)
+    readiness.add_argument("--max-duplicate-ratio", type=float, default=0.05)
+    readiness.add_argument("--fail-on-gate", action="store_true")
+    readiness.set_defaults(func=run_readiness)
 
     policy = sub.add_parser("policy", help="show collection safety policy")
     policy.set_defaults(func=run_policy)

--- a/src/peachtree/dedup.py
+++ b/src/peachtree/dedup.py
@@ -1,0 +1,157 @@
+"""Deterministic dataset deduplication for PeachTree."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+def normalized_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def record_signature(record: dict[str, Any]) -> str:
+    payload = {
+        "instruction": normalized_text(str(record.get("instruction", ""))),
+        "input": normalized_text(str(record.get("input", ""))),
+        "output": normalized_text(str(record.get("output", ""))),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class DuplicateGroup:
+    signature: str
+    kept_id: str
+    duplicate_ids: tuple[str, ...]
+    count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DedupReport:
+    source_path: str
+    output_path: str
+    input_count: int
+    output_count: int
+    duplicate_count: int
+    groups: tuple[DuplicateGroup, ...] = field(default_factory=tuple)
+
+    @property
+    def duplicate_ratio(self) -> float:
+        return round(self.duplicate_count / self.input_count, 4) if self.input_count else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_path": self.source_path,
+            "output_path": self.output_path,
+            "input_count": self.input_count,
+            "output_count": self.output_count,
+            "duplicate_count": self.duplicate_count,
+            "duplicate_ratio": self.duplicate_ratio,
+            "groups": [group.to_dict() for group in self.groups],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# PeachTree Deduplication Report",
+            "",
+            f"- Source: `{self.source_path}`",
+            f"- Output: `{self.output_path}`",
+            f"- Input records: `{self.input_count}`",
+            f"- Output records: `{self.output_count}`",
+            f"- Duplicate records removed: `{self.duplicate_count}`",
+            f"- Duplicate ratio: `{self.duplicate_ratio}`",
+            "",
+            "## Duplicate Groups",
+            "",
+        ]
+        if not self.groups:
+            lines.append("- None")
+        else:
+            for group in self.groups[:100]:
+                lines.append(f"- Kept `{group.kept_id}`; removed `{', '.join(group.duplicate_ids)}`")
+        return "\n".join(lines)
+
+
+class DatasetDeduplicator:
+    """Removes exact normalized instruction/input/output duplicates."""
+
+    def analyze(self, source_path: str | Path) -> DedupReport:
+        return self.deduplicate(source_path, output_path="", write_output=False)
+
+    def deduplicate(
+        self,
+        source_path: str | Path,
+        output_path: str | Path,
+        write_output: bool = True,
+    ) -> DedupReport:
+        source = Path(source_path)
+        records = self._read_jsonl(source)
+        seen: dict[str, dict[str, Any]] = {}
+        kept: list[dict[str, Any]] = []
+        duplicate_map: dict[str, list[str]] = {}
+
+        for index, record in enumerate(records, start=1):
+            signature = record_signature(record)
+            record_id = str(record.get("id") or f"line-{index}")
+            if signature in seen:
+                duplicate_map.setdefault(signature, []).append(record_id)
+            else:
+                seen[signature] = record
+                kept.append(record)
+
+        out = Path(output_path) if output_path else Path("")
+        if write_output:
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text("\n".join(json.dumps(record, sort_keys=True, ensure_ascii=False) for record in kept) + ("\n" if kept else ""), encoding="utf-8")
+
+        groups = []
+        for signature, duplicate_ids in sorted(duplicate_map.items()):
+            kept_record = seen[signature]
+            kept_id = str(kept_record.get("id") or signature[:16])
+            groups.append(DuplicateGroup(signature, kept_id, tuple(sorted(duplicate_ids)), len(duplicate_ids) + 1))
+
+        return DedupReport(
+            source_path=str(source),
+            output_path=str(out) if output_path else "",
+            input_count=len(records),
+            output_count=len(kept),
+            duplicate_count=sum(len(ids) for ids in duplicate_map.values()),
+            groups=tuple(groups),
+        )
+
+    def write_report(self, report: DedupReport, json_output: str | Path, markdown_output: str | Path | None = None) -> tuple[Path, Path | None]:
+        json_path = Path(json_output)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(report.to_json() + "\n", encoding="utf-8")
+        md_path: Path | None = None
+        if markdown_output:
+            md_path = Path(markdown_output)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(report.to_markdown() + "\n", encoding="utf-8")
+        return json_path, md_path
+
+    @staticmethod
+    def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                records.append(value)
+        return records

--- a/src/peachtree/quality.py
+++ b/src/peachtree/quality.py
@@ -1,0 +1,305 @@
+"""Dataset quality scoring and training readiness gates for PeachTree.
+
+This module is local-only. It scores reviewed PeachTree dataset JSONL files and
+produces human-readable gates before downstream model training.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+
+@dataclass(frozen=True)
+class QualityIssue:
+    severity: str
+    code: str
+    message: str
+    record_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RecordQualityScore:
+    record_id: str
+    score: int
+    passed: bool
+    issues: tuple[QualityIssue, ...] = field(default_factory=tuple)
+    source_repo: str = "unknown"
+    source_path: str = "unknown"
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["issues"] = [issue.to_dict() for issue in self.issues]
+        return data
+
+
+@dataclass(frozen=True)
+class QualityGate:
+    name: str
+    passed: bool
+    threshold: str
+    actual: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DatasetQualityReport:
+    dataset_path: str
+    record_count: int
+    average_score: float
+    min_score: int
+    passed_records: int
+    failed_records: int
+    gates: tuple[QualityGate, ...]
+    records: tuple[RecordQualityScore, ...]
+    issues: tuple[QualityIssue, ...] = field(default_factory=tuple)
+
+    @property
+    def gate_passed(self) -> bool:
+        return all(gate.passed for gate in self.gates)
+
+    @property
+    def readiness_level(self) -> str:
+        if self.gate_passed and self.average_score >= 90:
+            return "excellent"
+        if self.gate_passed:
+            return "ready"
+        if self.average_score >= 70:
+            return "review-required"
+        return "not-ready"
+
+    def to_dict(self, include_records: bool = True) -> dict[str, Any]:
+        data = {
+            "dataset_path": self.dataset_path,
+            "record_count": self.record_count,
+            "average_score": self.average_score,
+            "min_score": self.min_score,
+            "passed_records": self.passed_records,
+            "failed_records": self.failed_records,
+            "gate_passed": self.gate_passed,
+            "readiness_level": self.readiness_level,
+            "gates": [gate.to_dict() for gate in self.gates],
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+        if include_records:
+            data["records"] = [record.to_dict() for record in self.records]
+        return data
+
+    def to_json(self, include_records: bool = True) -> str:
+        return json.dumps(self.to_dict(include_records=include_records), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# PeachTree Dataset Quality Report",
+            "",
+            f"- Dataset: `{self.dataset_path}`",
+            f"- Records: `{self.record_count}`",
+            f"- Average score: `{self.average_score}`",
+            f"- Minimum score: `{self.min_score}`",
+            f"- Passed records: `{self.passed_records}`",
+            f"- Failed records: `{self.failed_records}`",
+            f"- Gate passed: `{'yes' if self.gate_passed else 'no'}`",
+            f"- Readiness level: `{self.readiness_level}`",
+            "",
+            "## Gates",
+            "",
+            "| Gate | Passed | Threshold | Actual | Message |",
+            "|---|---|---|---|---|",
+        ]
+        for gate in self.gates:
+            lines.append(
+                f"| `{gate.name}` | `{'yes' if gate.passed else 'no'}` | `{gate.threshold}` | `{gate.actual}` | {gate.message} |"
+            )
+        if self.issues:
+            lines += ["", "## Dataset Issues", ""]
+            for issue in self.issues:
+                lines.append(f"- `{issue.severity}` `{issue.code}`: {issue.message}")
+        failed = [record for record in self.records if not record.passed]
+        lines += ["", "## Failed Records", ""]
+        if not failed:
+            lines.append("- None")
+        else:
+            for record in failed[:100]:
+                issue_text = "; ".join(issue.code for issue in record.issues) or "unknown"
+                lines.append(f"- `{record.record_id}` score `{record.score}`: {issue_text}")
+        return "\n".join(lines)
+
+
+class DatasetQualityScorer:
+    """Scores PeachTree dataset records for training readiness."""
+
+    def __init__(
+        self,
+        min_record_score: int = 70,
+        min_average_score: int = 80,
+        max_failed_ratio: float = 0.10,
+        min_records: int = 1,
+    ) -> None:
+        self.min_record_score = min_record_score
+        self.min_average_score = min_average_score
+        self.max_failed_ratio = max_failed_ratio
+        self.min_records = min_records
+
+    def score_dataset(self, dataset_path: str | Path) -> DatasetQualityReport:
+        path = Path(dataset_path)
+        records = self._read_jsonl(path)
+        scores = tuple(self.score_record(record, index) for index, record in enumerate(records, start=1))
+        score_values = [record.score for record in scores]
+        average = round(mean(score_values), 2) if score_values else 0.0
+        min_score = min(score_values) if score_values else 0
+        failed = [record for record in scores if not record.passed]
+        failed_ratio = len(failed) / len(scores) if scores else 1.0
+
+        dataset_issues: list[QualityIssue] = []
+        if not records:
+            dataset_issues.append(QualityIssue("error", "empty_dataset", "dataset has no records"))
+        if any(record.source_repo == "unknown" for record in scores):
+            dataset_issues.append(QualityIssue("warning", "unknown_source_repo", "one or more records lack source_repo"))
+
+        gates = (
+            QualityGate(
+                "min_records",
+                len(records) >= self.min_records,
+                f">={self.min_records}",
+                str(len(records)),
+                "dataset must have enough records",
+            ),
+            QualityGate(
+                "min_average_score",
+                average >= self.min_average_score,
+                f">={self.min_average_score}",
+                str(average),
+                "dataset average quality score must meet threshold",
+            ),
+            QualityGate(
+                "max_failed_ratio",
+                failed_ratio <= self.max_failed_ratio,
+                f"<={self.max_failed_ratio}",
+                str(round(failed_ratio, 4)),
+                "too many records failed quality scoring",
+            ),
+            QualityGate(
+                "min_record_score",
+                all(record.score >= self.min_record_score for record in scores) if scores else False,
+                f">={self.min_record_score}",
+                str(min_score),
+                "all records should meet the minimum record score",
+            ),
+            QualityGate(
+                "provenance_required",
+                all(record.source_repo != "unknown" and record.source_path != "unknown" for record in scores) if scores else False,
+                "source_repo and source_path present",
+                "present" if scores and all(record.source_repo != "unknown" and record.source_path != "unknown" for record in scores) else "missing",
+                "all records must preserve provenance",
+            ),
+        )
+
+        return DatasetQualityReport(
+            dataset_path=str(path),
+            record_count=len(records),
+            average_score=average,
+            min_score=min_score,
+            passed_records=len(scores) - len(failed),
+            failed_records=len(failed),
+            gates=gates,
+            records=scores,
+            issues=tuple(dataset_issues),
+        )
+
+    def score_record(self, record: dict[str, Any], index: int) -> RecordQualityScore:
+        record_id = str(record.get("id") or f"line-{index}")
+        source_repo = str(record.get("source_repo", "unknown") or "unknown")
+        source_path = str(record.get("source_path", "unknown") or "unknown")
+        issues: list[QualityIssue] = []
+        score = 100
+
+        instruction = str(record.get("instruction", "")).strip()
+        user_input = str(record.get("input", "")).strip()
+        output = str(record.get("output", "")).strip()
+
+        if not instruction:
+            score -= 30
+            issues.append(QualityIssue("error", "missing_instruction", "record has no instruction", record_id))
+        elif len(instruction) < 10:
+            score -= 10
+            issues.append(QualityIssue("warning", "short_instruction", "instruction is very short", record_id))
+
+        if not output:
+            score -= 35
+            issues.append(QualityIssue("error", "missing_output", "record has no output", record_id))
+        elif len(output) < 20:
+            score -= 10
+            issues.append(QualityIssue("warning", "short_output", "output is very short", record_id))
+
+        if not user_input:
+            score -= 5
+            issues.append(QualityIssue("info", "empty_input", "record has no input/context", record_id))
+
+        if source_repo == "unknown":
+            score -= 15
+            issues.append(QualityIssue("error", "missing_source_repo", "record lacks source_repo provenance", record_id))
+        if source_path == "unknown":
+            score -= 15
+            issues.append(QualityIssue("error", "missing_source_path", "record lacks source_path provenance", record_id))
+        if not record.get("source_digest"):
+            score -= 10
+            issues.append(QualityIssue("warning", "missing_source_digest", "record lacks source digest", record_id))
+        if not record.get("license_id"):
+            score -= 5
+            issues.append(QualityIssue("warning", "missing_license", "record lacks license metadata", record_id))
+
+        safety_score = record.get("safety_score")
+        if isinstance(safety_score, (int, float)) and safety_score < 0.8:
+            score -= 15
+            issues.append(QualityIssue("error", "low_safety_score", "record safety score is below 0.8", record_id))
+
+        quality_score = record.get("quality_score")
+        if isinstance(quality_score, (int, float)) and quality_score < 0.5:
+            score -= 10
+            issues.append(QualityIssue("warning", "low_builder_quality_score", "builder quality score is below 0.5", record_id))
+
+        score = max(0, min(100, score))
+        return RecordQualityScore(
+            record_id=record_id,
+            score=score,
+            passed=score >= self.min_record_score and not any(issue.severity == "error" for issue in issues),
+            issues=tuple(issues),
+            source_repo=source_repo,
+            source_path=source_path,
+        )
+
+    @staticmethod
+    def write_report(report: DatasetQualityReport, json_output: str | Path, markdown_output: str | Path | None = None) -> tuple[Path, Path | None]:
+        json_path = Path(json_output)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(report.to_json() + "\n", encoding="utf-8")
+        md_path: Path | None = None
+        if markdown_output:
+            md_path = Path(markdown_output)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(report.to_markdown() + "\n", encoding="utf-8")
+        return json_path, md_path
+
+    @staticmethod
+    def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                value = {"id": "invalid-json", "instruction": "", "output": ""}
+            if isinstance(value, dict):
+                records.append(value)
+        return records

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+import json
+
+from peachtree.cli import main
+from peachtree.dedup import DatasetDeduplicator, record_signature
+from peachtree.quality import DatasetQualityScorer
+
+
+def _write_dataset(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n", encoding="utf-8")
+    return path
+
+
+def _good_record(record_id: str = "r1") -> dict:
+    return {
+        "id": record_id,
+        "instruction": "Explain the purpose of this source file for training.",
+        "input": "Repository: demo\nPath: README.md\n\nThis project contains safe dataset tooling.",
+        "output": "This source provides safe, provenance-backed training knowledge.",
+        "domain": "demo",
+        "source_repo": "0ai-Cyberviser/demo",
+        "source_path": "README.md",
+        "source_digest": "abc123",
+        "license_id": "apache-2.0",
+        "quality_score": 0.9,
+        "safety_score": 1.0,
+    }
+
+
+def test_score_good_record_passes():
+    score = DatasetQualityScorer().score_record(_good_record(), 1)
+    assert score.passed
+    assert score.score >= 90
+
+
+def test_score_bad_record_fails():
+    score = DatasetQualityScorer().score_record({"id": "bad", "instruction": "", "output": ""}, 1)
+    assert not score.passed
+    assert score.score < 70
+    assert any(issue.code == "missing_instruction" for issue in score.issues)
+
+
+def test_score_dataset_report_passes(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a"), _good_record("b")])
+    report = DatasetQualityScorer().score_dataset(dataset)
+    assert report.gate_passed
+    assert report.record_count == 2
+    assert report.readiness_level in {"ready", "excellent"}
+
+
+def test_score_dataset_missing_provenance_fails(tmp_path: Path):
+    record = _good_record("a")
+    record.pop("source_repo")
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [record])
+    report = DatasetQualityScorer().score_dataset(dataset)
+    assert not report.gate_passed
+    assert report.failed_records == 1
+
+
+def test_quality_markdown_contains_gates(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a")])
+    markdown = DatasetQualityScorer().score_dataset(dataset).to_markdown()
+    assert "Dataset Quality Report" in markdown
+    assert "min_average_score" in markdown
+
+
+def test_quality_write_report(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a")])
+    report = DatasetQualityScorer().score_dataset(dataset)
+    json_path, md_path = DatasetQualityScorer.write_report(report, tmp_path / "quality.json", tmp_path / "quality.md")
+    assert json_path.exists()
+    assert md_path is not None and md_path.exists()
+
+
+def test_record_signature_normalizes_whitespace():
+    a = {"instruction": "Hello   World", "input": "X", "output": "Y"}
+    b = {"instruction": "hello world", "input": "x", "output": "y"}
+    assert record_signature(a) == record_signature(b)
+
+
+def test_dedup_removes_duplicate_records(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a"), _good_record("b")])
+    out = tmp_path / "deduped.jsonl"
+    report = DatasetDeduplicator().deduplicate(dataset, out)
+    assert report.input_count == 2
+    assert report.output_count == 1
+    assert report.duplicate_count == 1
+    assert out.exists()
+
+
+def test_dedup_analyze_does_not_write_output(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a"), _good_record("b")])
+    report = DatasetDeduplicator().analyze(dataset)
+    assert report.duplicate_count == 1
+    assert report.output_path == ""
+
+
+def test_dedup_write_report(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a"), _good_record("b")])
+    report = DatasetDeduplicator().deduplicate(dataset, tmp_path / "deduped.jsonl")
+    json_path, md_path = DatasetDeduplicator().write_report(report, tmp_path / "dedup.json", tmp_path / "dedup.md")
+    assert json_path.exists()
+    assert md_path is not None and md_path.exists()
+
+
+def test_cli_score(tmp_path: Path, capsys):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a")])
+    rc = main(["score", "--dataset", str(dataset), "--summary-only"])
+    assert rc == 0
+    assert '"gate_passed": true' in capsys.readouterr().out
+
+
+def test_cli_score_writes_reports(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a")])
+    rc = main([
+        "score",
+        "--dataset", str(dataset),
+        "--json-output", str(tmp_path / "quality.json"),
+        "--markdown-output", str(tmp_path / "quality.md"),
+    ])
+    assert rc == 0
+    assert (tmp_path / "quality.json").exists()
+    assert (tmp_path / "quality.md").exists()
+
+
+def test_cli_dedup(tmp_path: Path, capsys):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a"), _good_record("b")])
+    rc = main(["dedup", "--source", str(dataset), "--output", str(tmp_path / "deduped.jsonl")])
+    assert rc == 0
+    assert '"duplicate_count": 1' in capsys.readouterr().out
+
+
+def test_cli_readiness_ready(tmp_path: Path, capsys):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [_good_record("a"), {**_good_record("b"), "input": "different context"}])
+    rc = main(["readiness", "--dataset", str(dataset), "--max-duplicate-ratio", "0.6"])
+    assert rc == 0
+    assert '"ready": true' in capsys.readouterr().out
+
+
+def test_cli_readiness_fail_on_gate(tmp_path: Path):
+    dataset = _write_dataset(tmp_path / "dataset.jsonl", [{"id": "bad", "instruction": "", "output": ""}])
+    rc = main(["readiness", "--dataset", str(dataset), "--fail-on-gate"])
+    assert rc == 2


### PR DESCRIPTION
Adds local-only dataset quality scoring, deterministic deduplication, and training readiness gates, including CLI commands, docs, CI, and tests.

Safety:
- Does not train models.
- Does not upload datasets.
- Does not scrape public GitHub.
- Preserves provenance review workflow.
- Adds quality, duplicate-ratio, and readiness gates before downstream training.