### PR TITLE
feat: add trainer handoff manifests, LoRA job cards, and dry-run training launch plans

### DIFF
--- a/.github/workflows/trainer-handoff.yml
+++ b/.github/workflows/trainer-handoff.yml
@@ -1,0 +1,33 @@
+name: PeachTree Trainer Handoff CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/peachtree/trainer_handoff.py"
+      - "src/peachtree/lora_job.py"
+      - "src/peachtree/training_plan.py"
+      - "src/peachtree/cli.py"
+      - "tests/test_trainer_handoff.py"
+      - "docs/TRAINER_HANDOFF.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trainer-handoff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - run: pytest -q tests/test_trainer_handoff.py
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -175,3 +175,16 @@ peachtree bundle data/datasets/example.jsonl reports/model-card.md --output dist
 ```
 
 These commands are local-only and do not train models, upload datasets, or scrape public GitHub.
+
+
+## Trainer handoff manifests
+
+PeachTree v0.9.0 adds trainer handoff manifests, LoRA job cards, and dry-run training launch plans.
+
+```bash
+peachtree handoff --dataset data/exports/example-chatml.jsonl --model-name Example-Lora --base-model mistralai/Mistral-7B-Instruct-v0.3 --output reports/handoff.json
+peachtree lora-card --dataset data/exports/example-chatml.jsonl --job-name example-lora --base-model mistralai/Mistral-7B-Instruct-v0.3 --output-dir outputs/example --output reports/lora-job-card.json
+peachtree train-plan --job-card reports/lora-job-card.json --output reports/dry-run-training-plan.json
+```
+
+These commands are dry-run only and do not launch training.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,3 +44,9 @@
 - Artifact signing metadata ✅
 - SBOM/provenance manifests ✅
 - Release bundles ✅
+
+
+## v0.9.0
+- Trainer handoff manifests ✅
+- LoRA job cards ✅
+- Dry-run training launch plans ✅

--- a/docs/TRAINER_HANDOFF.md
+++ b/docs/TRAINER_HANDOFF.md
@@ -1,0 +1,69 @@
+# Trainer Handoff Manifests, LoRA Job Cards, and Dry-Run Training Plans
+
+PeachTree v0.9.0 adds safe training-prep artifacts.
+
+It does **not** launch training, upload datasets, create cloud jobs, or call external trainer APIs.
+
+## New CLI
+
+```bash
+peachtree handoff
+peachtree lora-card
+peachtree train-plan
+```
+
+## Trainer handoff manifest
+
+```bash
+peachtree handoff \
+  --dataset data/exports/peachfuzz-chatml.jsonl \
+  --model-name PeachFuzz-Lora-v1 \
+  --base-model mistralai/Mistral-7B-Instruct-v0.3 \
+  --trainer-profile unsloth \
+  --dataset-format chatml \
+  --registry reports/registry.json \
+  --sbom reports/sbom.json \
+  --model-card reports/model-card.md \
+  --quality-report reports/quality.json \
+  --policy-report reports/policy-pack.json \
+  --license-report reports/license-gate.json \
+  --release-bundle dist/peachfuzz-dataset-v1.zip \
+  --output reports/trainer-handoff.json \
+  --markdown-output reports/trainer-handoff.md
+```
+
+## LoRA job card
+
+```bash
+peachtree lora-card \
+  --dataset data/exports/peachfuzz-chatml.jsonl \
+  --job-name peachfuzz-lora-v1 \
+  --base-model mistralai/Mistral-7B-Instruct-v0.3 \
+  --output-dir outputs/peachfuzz-lora-v1 \
+  --trainer-profile unsloth \
+  --dataset-format chatml \
+  --rank 16 \
+  --alpha 32 \
+  --learning-rate 0.0002 \
+  --epochs 1 \
+  --output reports/lora-job-card.json \
+  --markdown-output reports/lora-job-card.md
+```
+
+## Dry-run training launch plan
+
+```bash
+peachtree train-plan \
+  --job-card reports/lora-job-card.json \
+  --output reports/dry-run-training-plan.json \
+  --markdown-output reports/dry-run-training-plan.md
+```
+
+## Safety model
+
+- dry-run only
+- no shell execution
+- no model training
+- no dataset upload
+- no external training API calls
+- human approval required before training

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peachtree-ai"
-version = "0.8.0"
+version = "0.9.0"
 description = "Recursive learning-tree dataset engine for safe AI model training pipelines"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/peachtree/__init__.py
+++ b/src/peachtree/__init__.py
@@ -16,6 +16,9 @@ from .registry import DatasetRegistryBuilder, DatasetRegistry, RegistryArtifact
 from .signing import ArtifactSigner, SignatureEnvelope
 from .sbom import SBOMGenerator, SBOMDocument
 from .release_bundle import ReleaseBundleBuilder, ReleaseBundleReport
+from .trainer_handoff import TrainerHandoffBuilder, TrainerHandoffManifest
+from .lora_job import LoraJobCardBuilder, LoraJobCard, LoraHyperparameters
+from .training_plan import DryRunTrainingPlanner, DryRunTrainingPlan
 from .safety import SafetyGate
 
 __all__ = [
@@ -57,6 +60,13 @@ __all__ = [
     "SBOMDocument",
     "ReleaseBundleBuilder",
     "ReleaseBundleReport",
+    "TrainerHandoffBuilder",
+    "TrainerHandoffManifest",
+    "LoraJobCardBuilder",
+    "LoraJobCard",
+    "LoraHyperparameters",
+    "DryRunTrainingPlanner",
+    "DryRunTrainingPlan",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/peachtree/builder.py
+++ b/src/peachtree/builder.py
@@ -55,7 +55,7 @@ class DatasetBuilder:
             record_count=len(records),
             source_count=len(sources),
             domain=self.domain,
-            builder_version="0.8.0",
+            builder_version="0.9.0",
             source_digests=tuple(sorted({source.digest for source in sources})),
             policy={"secret_filtering": True, "license_filtering": True, "provenance_required": True},
         )

--- a/src/peachtree/cli.py
+++ b/src/peachtree/cli.py
@@ -24,6 +24,9 @@ from .registry import DatasetRegistryBuilder
 from .signing import ArtifactSigner
 from .sbom import SBOMGenerator
 from .release_bundle import ReleaseBundleBuilder
+from .trainer_handoff import TrainerHandoffBuilder
+from .lora_job import LoraJobCardBuilder, LoraHyperparameters
+from .training_plan import DryRunTrainingPlanner
 
 
 def run_plan(args: argparse.Namespace) -> int:
@@ -445,6 +448,101 @@ def run_bundle(args: argparse.Namespace) -> int:
     return 0
 
 
+
+
+
+def run_handoff(args: argparse.Namespace) -> int:
+    builder = TrainerHandoffBuilder()
+    manifest = builder.build(
+        dataset_path=args.dataset,
+        model_name=args.model_name,
+        base_model=args.base_model,
+        trainer_profile=args.trainer_profile,
+        dataset_format=args.dataset_format,
+        registry_path=args.registry,
+        sbom_path=args.sbom,
+        model_card_path=args.model_card,
+        quality_report_path=args.quality_report,
+        policy_report_path=args.policy_report,
+        license_report_path=args.license_report,
+        release_bundle_path=args.release_bundle,
+        metadata={"generated_for": "trainer_handoff"},
+    )
+    if args.output or args.markdown_output:
+        builder.write(manifest, args.output or "reports/trainer-handoff.json", args.markdown_output)
+    if args.format == "markdown":
+        print(manifest.to_markdown())
+    else:
+        print(manifest.to_json())
+    return 0
+
+
+def run_lora_card(args: argparse.Namespace) -> int:
+    hp = LoraHyperparameters(
+        rank=args.rank,
+        alpha=args.alpha,
+        dropout=args.dropout,
+        learning_rate=args.learning_rate,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        max_seq_length=args.max_seq_length,
+        warmup_ratio=args.warmup_ratio,
+    )
+    card = LoraJobCardBuilder().build(
+        dataset_path=args.dataset,
+        job_name=args.job_name,
+        base_model=args.base_model,
+        output_dir=args.output_dir,
+        trainer_profile=args.trainer_profile,
+        dataset_format=args.dataset_format,
+        hyperparameters=hp,
+        metadata={"generated_for": "lora_job_card"},
+    )
+    if args.output or args.markdown_output:
+        LoraJobCardBuilder().write(card, args.output or "reports/lora-job-card.json", args.markdown_output)
+    if args.format == "markdown":
+        print(card.to_markdown())
+    else:
+        print(card.to_json())
+    return 0
+
+
+def run_train_plan(args: argparse.Namespace) -> int:
+    planner = DryRunTrainingPlanner()
+    if args.job_card:
+        card = planner.read_job_card(args.job_card)
+    else:
+        hp = LoraHyperparameters(
+            rank=args.rank,
+            alpha=args.alpha,
+            dropout=args.dropout,
+            learning_rate=args.learning_rate,
+            epochs=args.epochs,
+            batch_size=args.batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            max_seq_length=args.max_seq_length,
+            warmup_ratio=args.warmup_ratio,
+        )
+        card = LoraJobCardBuilder().build(
+            dataset_path=args.dataset,
+            job_name=args.job_name,
+            base_model=args.base_model,
+            output_dir=args.output_dir,
+            trainer_profile=args.trainer_profile,
+            dataset_format=args.dataset_format,
+            hyperparameters=hp,
+        )
+    plan = planner.build(card)
+    if args.output or args.markdown_output:
+        planner.write(plan, args.output or "reports/dry-run-training-plan.json", args.markdown_output)
+    if args.format == "markdown":
+        print(plan.to_markdown())
+    else:
+        print(plan.to_json())
+    return 0
+
+
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="peachtree", description="Recursive learning-tree dataset engine")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -659,6 +757,67 @@ def make_parser() -> argparse.ArgumentParser:
     bundle.add_argument("--report")
     bundle.add_argument("--format", choices=["json", "markdown"], default="json")
     bundle.set_defaults(func=run_bundle)
+
+    handoff = sub.add_parser("handoff", help="create a trainer handoff manifest")
+    handoff.add_argument("--dataset", required=True)
+    handoff.add_argument("--model-name", required=True)
+    handoff.add_argument("--base-model", required=True)
+    handoff.add_argument("--trainer-profile", default="unsloth")
+    handoff.add_argument("--dataset-format", default="chatml")
+    handoff.add_argument("--registry")
+    handoff.add_argument("--sbom")
+    handoff.add_argument("--model-card")
+    handoff.add_argument("--quality-report")
+    handoff.add_argument("--policy-report")
+    handoff.add_argument("--license-report")
+    handoff.add_argument("--release-bundle")
+    handoff.add_argument("--format", choices=["json", "markdown"], default="json")
+    handoff.add_argument("--output")
+    handoff.add_argument("--markdown-output")
+    handoff.set_defaults(func=run_handoff)
+
+    lora_card = sub.add_parser("lora-card", help="create a LoRA job card without launching training")
+    lora_card.add_argument("--dataset", required=True)
+    lora_card.add_argument("--job-name", required=True)
+    lora_card.add_argument("--base-model", required=True)
+    lora_card.add_argument("--output-dir", required=True)
+    lora_card.add_argument("--trainer-profile", default="unsloth")
+    lora_card.add_argument("--dataset-format", default="chatml")
+    lora_card.add_argument("--rank", type=int, default=16)
+    lora_card.add_argument("--alpha", type=int, default=32)
+    lora_card.add_argument("--dropout", type=float, default=0.05)
+    lora_card.add_argument("--learning-rate", type=float, default=2e-4)
+    lora_card.add_argument("--epochs", type=float, default=1.0)
+    lora_card.add_argument("--batch-size", type=int, default=2)
+    lora_card.add_argument("--gradient-accumulation-steps", type=int, default=4)
+    lora_card.add_argument("--max-seq-length", type=int, default=4096)
+    lora_card.add_argument("--warmup-ratio", type=float, default=0.03)
+    lora_card.add_argument("--format", choices=["json", "markdown"], default="json")
+    lora_card.add_argument("--output")
+    lora_card.add_argument("--markdown-output")
+    lora_card.set_defaults(func=run_lora_card)
+
+    train_plan = sub.add_parser("train-plan", help="create a dry-run training launch plan")
+    train_plan.add_argument("--job-card")
+    train_plan.add_argument("--dataset")
+    train_plan.add_argument("--job-name", default="peachtree-lora-job")
+    train_plan.add_argument("--base-model", default="mistralai/Mistral-7B-Instruct-v0.3")
+    train_plan.add_argument("--output-dir", default="outputs/lora")
+    train_plan.add_argument("--trainer-profile", default="unsloth")
+    train_plan.add_argument("--dataset-format", default="chatml")
+    train_plan.add_argument("--rank", type=int, default=16)
+    train_plan.add_argument("--alpha", type=int, default=32)
+    train_plan.add_argument("--dropout", type=float, default=0.05)
+    train_plan.add_argument("--learning-rate", type=float, default=2e-4)
+    train_plan.add_argument("--epochs", type=float, default=1.0)
+    train_plan.add_argument("--batch-size", type=int, default=2)
+    train_plan.add_argument("--gradient-accumulation-steps", type=int, default=4)
+    train_plan.add_argument("--max-seq-length", type=int, default=4096)
+    train_plan.add_argument("--warmup-ratio", type=float, default=0.03)
+    train_plan.add_argument("--format", choices=["json", "markdown"], default="json")
+    train_plan.add_argument("--output")
+    train_plan.add_argument("--markdown-output")
+    train_plan.set_defaults(func=run_train_plan)
 
     policy = sub.add_parser("policy", help="show collection safety policy")
     policy.set_defaults(func=run_policy)

--- a/src/peachtree/lora_job.py
+++ b/src/peachtree/lora_job.py
@@ -1,0 +1,143 @@
+"""LoRA job card generation for PeachTree trainer handoff."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from .registry import sha256_file
+
+
+SUPPORTED_TRAINER_PROFILES = ("unsloth", "axolotl", "transformers", "modal", "colab", "kaggle")
+SUPPORTED_DATASET_FORMATS = ("chatml", "alpaca", "sharegpt")
+
+
+@dataclass(frozen=True)
+class LoraHyperparameters:
+    rank: int = 16
+    alpha: int = 32
+    dropout: float = 0.05
+    learning_rate: float = 2e-4
+    epochs: float = 1.0
+    batch_size: int = 2
+    gradient_accumulation_steps: int = 4
+    max_seq_length: int = 4096
+    warmup_ratio: float = 0.03
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LoraJobCard:
+    job_name: str
+    base_model: str
+    dataset_path: str
+    dataset_format: str
+    trainer_profile: str
+    output_dir: str
+    created_at: str
+    dataset_sha256: str
+    hyperparameters: LoraHyperparameters
+    safety: dict[str, Any]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_name": self.job_name,
+            "base_model": self.base_model,
+            "dataset_path": self.dataset_path,
+            "dataset_format": self.dataset_format,
+            "trainer_profile": self.trainer_profile,
+            "output_dir": self.output_dir,
+            "created_at": self.created_at,
+            "dataset_sha256": self.dataset_sha256,
+            "hyperparameters": self.hyperparameters.to_dict(),
+            "safety": self.safety,
+            "metadata": self.metadata,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        hp = self.hyperparameters
+        lines = [
+            "# PeachTree LoRA Job Card",
+            "",
+            f"- Job: `{self.job_name}`",
+            f"- Base model: `{self.base_model}`",
+            f"- Trainer profile: `{self.trainer_profile}`",
+            f"- Dataset: `{self.dataset_path}`",
+            f"- Dataset format: `{self.dataset_format}`",
+            f"- Output dir: `{self.output_dir}`",
+            f"- Dataset SHA-256: `{self.dataset_sha256}`",
+            "",
+            "## Hyperparameters",
+            "",
+        ]
+        for key, value in hp.to_dict().items():
+            lines.append(f"- {key}: `{value}`")
+        lines += ["", "## Safety", ""]
+        for key, value in self.safety.items():
+            lines.append(f"- {key}: `{value}`")
+        return "\n".join(lines)
+
+
+class LoraJobCardBuilder:
+    """Builds LoRA job cards without launching training."""
+
+    def build(
+        self,
+        dataset_path: str | Path,
+        job_name: str,
+        base_model: str,
+        output_dir: str,
+        trainer_profile: str = "unsloth",
+        dataset_format: str = "chatml",
+        hyperparameters: LoraHyperparameters | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> LoraJobCard:
+        profile = self._require(trainer_profile, SUPPORTED_TRAINER_PROFILES, "trainer profile")
+        fmt = self._require(dataset_format, SUPPORTED_DATASET_FORMATS, "dataset format")
+        dataset = Path(dataset_path)
+        if not dataset.exists():
+            raise FileNotFoundError(str(dataset))
+        return LoraJobCard(
+            job_name=job_name,
+            base_model=base_model,
+            dataset_path=str(dataset),
+            dataset_format=fmt,
+            trainer_profile=profile,
+            output_dir=output_dir,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            dataset_sha256=sha256_file(dataset),
+            hyperparameters=hyperparameters or LoraHyperparameters(),
+            safety={
+                "dry_run_only": True,
+                "does_not_train_models": True,
+                "requires_human_approval_before_training": True,
+                "review_handoff_manifest_first": True,
+            },
+            metadata=metadata or {},
+        )
+
+    def write(self, card: LoraJobCard, output_path: str | Path, markdown_output: str | Path | None = None) -> tuple[Path, Path | None]:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(card.to_json() + "\n", encoding="utf-8")
+        md_path: Path | None = None
+        if markdown_output:
+            md_path = Path(markdown_output)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(card.to_markdown() + "\n", encoding="utf-8")
+        return out, md_path
+
+    @staticmethod
+    def _require(value: str, allowed: tuple[str, ...], label: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in allowed:
+            raise ValueError(f"unsupported {label}: {value}")
+        return normalized

--- a/src/peachtree/trainer_handoff.py
+++ b/src/peachtree/trainer_handoff.py
@@ -1,0 +1,187 @@
+"""Trainer handoff manifests for PeachTree.
+
+This module prepares local review artifacts for downstream training systems.
+It does not train models, upload datasets, or call external trainer APIs.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from .registry import sha256_file
+
+
+@dataclass(frozen=True)
+class HandoffArtifact:
+    name: str
+    path: str
+    kind: str
+    sha256: str
+    size_bytes: int
+    required: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrainerHandoffManifest:
+    model_name: str
+    base_model: str
+    trainer_profile: str
+    dataset_path: str
+    dataset_format: str
+    created_at: str
+    artifacts: tuple[HandoffArtifact, ...]
+    safety: dict[str, Any]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def artifact_count(self) -> int:
+        return len(self.artifacts)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "base_model": self.base_model,
+            "trainer_profile": self.trainer_profile,
+            "dataset_path": self.dataset_path,
+            "dataset_format": self.dataset_format,
+            "created_at": self.created_at,
+            "artifact_count": self.artifact_count,
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "safety": self.safety,
+            "metadata": self.metadata,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# PeachTree Trainer Handoff Manifest",
+            "",
+            f"- Model name: `{self.model_name}`",
+            f"- Base model: `{self.base_model}`",
+            f"- Trainer profile: `{self.trainer_profile}`",
+            f"- Dataset: `{self.dataset_path}`",
+            f"- Dataset format: `{self.dataset_format}`",
+            f"- Created: `{self.created_at}`",
+            "",
+            "## Artifacts",
+            "",
+            "| Name | Kind | Required | Size | SHA-256 | Path |",
+            "|---|---|---|---:|---|---|",
+        ]
+        for artifact in self.artifacts:
+            lines.append(
+                f"| `{artifact.name}` | `{artifact.kind}` | `{'yes' if artifact.required else 'no'}` | {artifact.size_bytes} | `{artifact.sha256[:16]}...` | `{artifact.path}` |"
+            )
+        lines += ["", "## Safety", ""]
+        for key, value in self.safety.items():
+            lines.append(f"- {key}: `{value}`")
+        return "\n".join(lines)
+
+
+class TrainerHandoffBuilder:
+    """Builds trainer handoff manifests from reviewed local artifacts."""
+
+    artifact_kinds = {
+        "dataset": "dataset",
+        "registry": "registry",
+        "sbom": "sbom",
+        "model_card": "model-card",
+        "quality_report": "quality-report",
+        "policy_report": "policy-report",
+        "license_report": "license-report",
+        "release_bundle": "release-bundle",
+    }
+
+    def build(
+        self,
+        dataset_path: str | Path,
+        model_name: str,
+        base_model: str,
+        trainer_profile: str = "unsloth",
+        dataset_format: str = "chatml",
+        registry_path: str | Path | None = None,
+        sbom_path: str | Path | None = None,
+        model_card_path: str | Path | None = None,
+        quality_report_path: str | Path | None = None,
+        policy_report_path: str | Path | None = None,
+        license_report_path: str | Path | None = None,
+        release_bundle_path: str | Path | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> TrainerHandoffManifest:
+        artifacts = [
+            self._artifact(dataset_path, "dataset", required=True),
+        ]
+        optional = {
+            "registry": registry_path,
+            "sbom": sbom_path,
+            "model_card": model_card_path,
+            "quality_report": quality_report_path,
+            "policy_report": policy_report_path,
+            "license_report": license_report_path,
+            "release_bundle": release_bundle_path,
+        }
+        for kind, path in optional.items():
+            if path:
+                artifacts.append(self._artifact(path, kind, required=False))
+
+        return TrainerHandoffManifest(
+            model_name=model_name,
+            base_model=base_model,
+            trainer_profile=trainer_profile,
+            dataset_path=str(dataset_path),
+            dataset_format=dataset_format,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            artifacts=tuple(artifact for artifact in artifacts if artifact is not None),
+            safety=self.safety(),
+            metadata=metadata or {},
+        )
+
+    def write(
+        self,
+        manifest: TrainerHandoffManifest,
+        output_path: str | Path,
+        markdown_output: str | Path | None = None,
+    ) -> tuple[Path, Path | None]:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(manifest.to_json() + "\n", encoding="utf-8")
+        md_path: Path | None = None
+        if markdown_output:
+            md_path = Path(markdown_output)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(manifest.to_markdown() + "\n", encoding="utf-8")
+        return out, md_path
+
+    @classmethod
+    def _artifact(cls, path: str | Path, kind: str, required: bool) -> HandoffArtifact | None:
+        p = Path(path)
+        if not p.exists() or not p.is_file():
+            if required:
+                raise FileNotFoundError(str(p))
+            return None
+        return HandoffArtifact(
+            name=p.name,
+            path=str(p),
+            kind=cls.artifact_kinds.get(kind, kind),
+            sha256=sha256_file(p),
+            size_bytes=p.stat().st_size,
+            required=required,
+        )
+
+    @staticmethod
+    def safety() -> dict[str, Any]:
+        return {
+            "dry_run_only": True,
+            "does_not_train_models": True,
+            "does_not_upload_datasets": True,
+            "does_not_call_training_apis": True,
+            "requires_human_approval_before_training": True,
+        }

--- a/src/peachtree/training_plan.py
+++ b/src/peachtree/training_plan.py
@@ -1,0 +1,144 @@
+"""Dry-run training launch plans for PeachTree.
+
+The launch plans are review artifacts only. They contain command previews and
+checklists but never execute training jobs.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from .lora_job import LoraJobCard, LoraHyperparameters
+
+
+@dataclass(frozen=True)
+class DryRunTrainingPlan:
+    job_name: str
+    trainer_profile: str
+    created_at: str
+    command_preview: tuple[str, ...]
+    checklist: tuple[str, ...]
+    environment: dict[str, Any]
+    safety: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# PeachTree Dry-Run Training Launch Plan",
+            "",
+            f"- Job: `{self.job_name}`",
+            f"- Trainer profile: `{self.trainer_profile}`",
+            f"- Created: `{self.created_at}`",
+            "",
+            "## Command Preview",
+            "",
+        ]
+        lines.extend(f"```bash\n{command}\n```" for command in self.command_preview)
+        lines += ["", "## Review Checklist", ""]
+        lines.extend(f"- [ ] {item}" for item in self.checklist)
+        lines += ["", "## Safety", ""]
+        for key, value in self.safety.items():
+            lines.append(f"- {key}: `{value}`")
+        return "\n".join(lines)
+
+
+class DryRunTrainingPlanner:
+    """Creates trainer-specific dry-run plans without executing them."""
+
+    def build(self, job_card: LoraJobCard) -> DryRunTrainingPlan:
+        commands = self._commands(job_card)
+        return DryRunTrainingPlan(
+            job_name=job_card.job_name,
+            trainer_profile=job_card.trainer_profile,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            command_preview=tuple(commands),
+            checklist=(
+                "Verify dataset license/compliance gate passed.",
+                "Verify quality/readiness gates passed.",
+                "Verify model card and SBOM are present.",
+                "Confirm base model license permits intended use.",
+                "Confirm GPU, storage, and secrets are configured outside PeachTree.",
+                "Obtain human approval before launching actual training.",
+            ),
+            environment={
+                "base_model": job_card.base_model,
+                "dataset_path": job_card.dataset_path,
+                "dataset_format": job_card.dataset_format,
+                "output_dir": job_card.output_dir,
+                "hyperparameters": job_card.hyperparameters.to_dict(),
+            },
+            safety={
+                "dry_run_only": True,
+                "commands_are_preview_only": True,
+                "does_not_execute_shell": True,
+                "does_not_train_models": True,
+                "does_not_upload_datasets": True,
+            },
+        )
+
+    def write(self, plan: DryRunTrainingPlan, output_path: str | Path, markdown_output: str | Path | None = None) -> tuple[Path, Path | None]:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(plan.to_json() + "\n", encoding="utf-8")
+        md_path: Path | None = None
+        if markdown_output:
+            md_path = Path(markdown_output)
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(plan.to_markdown() + "\n", encoding="utf-8")
+        return out, md_path
+
+    @staticmethod
+    def read_job_card(path: str | Path) -> LoraJobCard:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        hp = LoraHyperparameters(**data["hyperparameters"])
+        return LoraJobCard(
+            job_name=data["job_name"],
+            base_model=data["base_model"],
+            dataset_path=data["dataset_path"],
+            dataset_format=data["dataset_format"],
+            trainer_profile=data["trainer_profile"],
+            output_dir=data["output_dir"],
+            created_at=data["created_at"],
+            dataset_sha256=data["dataset_sha256"],
+            hyperparameters=hp,
+            safety=data.get("safety", {}),
+            metadata=data.get("metadata", {}),
+        )
+
+    @staticmethod
+    def _commands(card: LoraJobCard) -> list[str]:
+        hp = card.hyperparameters
+        common = (
+            f"--base-model {card.base_model} "
+            f"--dataset {card.dataset_path} "
+            f"--dataset-format {card.dataset_format} "
+            f"--output-dir {card.output_dir} "
+            f"--lora-rank {hp.rank} "
+            f"--lora-alpha {hp.alpha} "
+            f"--learning-rate {hp.learning_rate} "
+            f"--epochs {hp.epochs} "
+            f"--batch-size {hp.batch_size} "
+            f"--grad-accum {hp.gradient_accumulation_steps} "
+            f"--max-seq-length {hp.max_seq_length}"
+        )
+        if card.trainer_profile == "unsloth":
+            return [f"# DRY RUN ONLY: python train_unsloth_lora.py {common}"]
+        if card.trainer_profile == "axolotl":
+            return [f"# DRY RUN ONLY: axolotl train generated_config.yml  # derived from {common}"]
+        if card.trainer_profile == "transformers":
+            return [f"# DRY RUN ONLY: accelerate launch train_lora.py {common}"]
+        if card.trainer_profile == "modal":
+            return [f"# DRY RUN ONLY: modal run train_lora.py -- {common}"]
+        if card.trainer_profile == "colab":
+            return [f"# DRY RUN ONLY: open Colab notebook and fill parameters: {common}"]
+        if card.trainer_profile == "kaggle":
+            return [f"# DRY RUN ONLY: kaggle kernels push with generated job spec: {common}"]
+        return [f"# DRY RUN ONLY: unsupported trainer profile preview for {card.trainer_profile}"]

--- a/tests/test_trainer_handoff.py
+++ b/tests/test_trainer_handoff.py
@@ -1,0 +1,191 @@
+from pathlib import Path
+import json
+
+from peachtree.cli import main
+from peachtree.lora_job import LoraHyperparameters, LoraJobCardBuilder
+from peachtree.trainer_handoff import TrainerHandoffBuilder
+from peachtree.training_plan import DryRunTrainingPlanner
+
+
+def _dataset(tmp_path: Path) -> Path:
+    path = tmp_path / "dataset.jsonl"
+    path.write_text(json.dumps({"id": "a", "instruction": "Explain safely.", "output": "Safe answer."}) + "\n", encoding="utf-8")
+    return path
+
+
+def _artifact(tmp_path: Path, name: str, content: str = "{}") -> Path:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content + "\n", encoding="utf-8")
+    return path
+
+
+def test_handoff_manifest_includes_required_dataset(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    manifest = TrainerHandoffBuilder().build(
+        dataset,
+        model_name="DemoModel",
+        base_model="mistralai/Mistral-7B-Instruct-v0.3",
+    )
+    assert manifest.artifact_count == 1
+    assert manifest.artifacts[0].required
+    assert manifest.safety["does_not_train_models"] is True
+
+
+def test_handoff_manifest_optional_artifacts(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    registry = _artifact(tmp_path, "registry.json")
+    sbom = _artifact(tmp_path, "sbom.json")
+    manifest = TrainerHandoffBuilder().build(
+        dataset,
+        model_name="DemoModel",
+        base_model="base",
+        registry_path=registry,
+        sbom_path=sbom,
+    )
+    kinds = {artifact.kind for artifact in manifest.artifacts}
+    assert {"dataset", "registry", "sbom"} <= kinds
+
+
+def test_handoff_write_reports(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    manifest = TrainerHandoffBuilder().build(dataset, "DemoModel", "base")
+    out, md = TrainerHandoffBuilder().write(manifest, tmp_path / "handoff.json", tmp_path / "handoff.md")
+    assert out.exists()
+    assert md is not None and md.exists()
+
+
+def test_lora_card_defaults(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    card = LoraJobCardBuilder().build(
+        dataset,
+        job_name="demo-lora",
+        base_model="base",
+        output_dir="outputs/demo",
+    )
+    assert card.trainer_profile == "unsloth"
+    assert card.hyperparameters.rank == 16
+    assert card.safety["dry_run_only"] is True
+
+
+def test_lora_card_custom_hyperparameters(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    hp = LoraHyperparameters(rank=8, alpha=16, learning_rate=1e-4)
+    card = LoraJobCardBuilder().build(dataset, "demo", "base", "outputs/demo", hyperparameters=hp)
+    assert card.hyperparameters.rank == 8
+    assert card.hyperparameters.learning_rate == 1e-4
+
+
+def test_lora_card_write_reports(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    card = LoraJobCardBuilder().build(dataset, "demo", "base", "outputs/demo")
+    out, md = LoraJobCardBuilder().write(card, tmp_path / "job.json", tmp_path / "job.md")
+    assert out.exists()
+    assert md is not None and md.exists()
+
+
+def test_training_plan_from_card(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    card = LoraJobCardBuilder().build(dataset, "demo", "base", "outputs/demo")
+    plan = DryRunTrainingPlanner().build(card)
+    assert plan.safety["does_not_execute_shell"] is True
+    assert "DRY RUN ONLY" in plan.command_preview[0]
+
+
+def test_training_plan_write_reports(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    card = LoraJobCardBuilder().build(dataset, "demo", "base", "outputs/demo")
+    plan = DryRunTrainingPlanner().build(card)
+    out, md = DryRunTrainingPlanner().write(plan, tmp_path / "plan.json", tmp_path / "plan.md")
+    assert out.exists()
+    assert md is not None and md.exists()
+
+
+def test_training_plan_read_job_card(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    card = LoraJobCardBuilder().build(dataset, "demo", "base", "outputs/demo")
+    out, _ = LoraJobCardBuilder().write(card, tmp_path / "job.json")
+    loaded = DryRunTrainingPlanner().read_job_card(out)
+    assert loaded.job_name == "demo"
+
+
+def test_cli_handoff(tmp_path: Path, capsys):
+    dataset = _dataset(tmp_path)
+    rc = main([
+        "handoff",
+        "--dataset", str(dataset),
+        "--model-name", "DemoModel",
+        "--base-model", "base",
+    ])
+    assert rc == 0
+    assert '"does_not_train_models": true' in capsys.readouterr().out
+
+
+def test_cli_lora_card(tmp_path: Path, capsys):
+    dataset = _dataset(tmp_path)
+    rc = main([
+        "lora-card",
+        "--dataset", str(dataset),
+        "--job-name", "demo",
+        "--base-model", "base",
+        "--output-dir", "outputs/demo",
+    ])
+    assert rc == 0
+    assert '"job_name": "demo"' in capsys.readouterr().out
+
+
+def test_cli_lora_card_writes_output(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    rc = main([
+        "lora-card",
+        "--dataset", str(dataset),
+        "--job-name", "demo",
+        "--base-model", "base",
+        "--output-dir", "outputs/demo",
+        "--output", str(tmp_path / "job.json"),
+        "--markdown-output", str(tmp_path / "job.md"),
+    ])
+    assert rc == 0
+    assert (tmp_path / "job.json").exists()
+    assert (tmp_path / "job.md").exists()
+
+
+def test_cli_train_plan_from_job_card(tmp_path: Path, capsys):
+    dataset = _dataset(tmp_path)
+    main([
+        "lora-card",
+        "--dataset", str(dataset),
+        "--job-name", "demo",
+        "--base-model", "base",
+        "--output-dir", "outputs/demo",
+        "--output", str(tmp_path / "job.json"),
+    ])
+    rc = main(["train-plan", "--job-card", str(tmp_path / "job.json")])
+    assert rc == 0
+    assert "DRY RUN ONLY" in capsys.readouterr().out
+
+
+def test_cli_train_plan_direct(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    rc = main([
+        "train-plan",
+        "--dataset", str(dataset),
+        "--job-name", "demo",
+        "--base-model", "base",
+        "--output-dir", "outputs/demo",
+        "--output", str(tmp_path / "plan.json"),
+        "--markdown-output", str(tmp_path / "plan.md"),
+    ])
+    assert rc == 0
+    assert (tmp_path / "plan.json").exists()
+    assert (tmp_path / "plan.md").exists()
+
+
+def test_lora_card_rejects_bad_profile(tmp_path: Path):
+    dataset = _dataset(tmp_path)
+    try:
+        LoraJobCardBuilder().build(dataset, "demo", "base", "outputs/demo", trainer_profile="bad")
+    except ValueError as exc:
+        assert "unsupported trainer profile" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
Adds local-only trainer handoff manifests, LoRA job cards, and dry-run training launch plans, including CLI commands, docs, CI, and tests.

Safety:
- Dry-run only.
- Does not train models.
- Does not upload datasets.
- Does not execute shell commands.
- Does not call external training APIs.
- Requires human approval before real training.